### PR TITLE
Build and serve gzip-compressed static files.

### DIFF
--- a/backend/server.go
+++ b/backend/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,7 +82,8 @@ func (s *Server) route() {
 	s.r.Path("/metrics").Handler(
 		prometheus.InstrumentHandler("metrics", prometheus.UninstrumentedHandler()))
 
-	s.r.PathPrefix("/static/").Handler(prometheus.InstrumentHandlerFunc("static", s.handleStatic))
+	s.r.PathPrefix("/static/").Handler(
+		prometheus.InstrumentHandler("static", http.StripPrefix("/static", http.HandlerFunc(s.handleStatic))))
 
 	s.r.Handle("/", prometheus.InstrumentHandlerFunc("home", s.handleHomeStatic))
 
@@ -100,13 +102,11 @@ func (s *Server) handleProbe(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
-	if s.staticPath == "" || r.URL.Path == "/static/" {
+	if s.staticPath == "" || r.URL.Path == "" {
 		http.NotFound(w, r)
 		return
 	}
-
-	handler := http.StripPrefix("/static/", http.FileServer(http.Dir(s.staticPath)))
-	handler.ServeHTTP(w, r)
+	s.serveGzippedFile(w, r, path.Clean(r.URL.Path))
 }
 
 func (s *Server) handleRoomStatic(w http.ResponseWriter, r *http.Request) {
@@ -120,15 +120,57 @@ func (s *Server) handleRoomStatic(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	http.ServeFile(w, r, path.Join(s.staticPath, "index.html"))
+	s.serveGzippedFile(w, r, "index.html")
 }
 
 func (s *Server) handleHomeStatic(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, path.Join(s.staticPath, "home.html"))
+	s.serveGzippedFile(w, r, "home.html")
 }
 
 func (s *Server) handleRobotsTxt(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, path.Join(s.staticPath, "robots.txt"))
+	s.serveGzippedFile(w, r, "robots.txt")
+}
+
+func (s *Server) serveGzippedFile(w http.ResponseWriter, r *http.Request, filename string) {
+	dir := http.Dir(s.staticPath)
+	var err error
+	var f http.File
+	gzipped := false
+
+	if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		f, err = dir.Open(filename + ".gz")
+		if err != nil {
+			f = nil
+		} else {
+			gzipped = true
+		}
+	}
+
+	if f == nil {
+		f, err = dir.Open(filename)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	defer f.Close()
+
+	d, err := f.Stat()
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	name := d.Name()
+	if gzipped {
+		name = strings.TrimSuffix(name, ".gz")
+		header := w.Header()
+		header.Set("Content-Encoding", "gzip")
+		header.Add("Vary", "Accept-Encoding")
+	}
+
+	http.ServeContent(w, r, name, d.ModTime(), f)
 }
 
 func (s *Server) generateAgentID() ([]byte, error) {

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp')
 var gutil = require('gulp-util')
+var gzip = require('gulp-gzip')
 var less = require('gulp-less')
 var autoprefixer = require('gulp-autoprefixer')
 var uglify = require('gulp-uglify')
@@ -158,6 +159,14 @@ function watchifyTask(name, bundler, outFile, dest) {
 watchifyTask('heim-watchify', heimBundler, 'main.js', heimDest)
 watchifyTask('embed-watchify', embedBundler, 'embed.js', embedDest)
 
+gulp.task('build-statics', ['heim-js', 'raven-js', 'embed-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html'])
+
+gulp.task('gzip', ['build-statics'], function() {
+  return gulp.src(['./build/**/*.js', './build/**/*.js.map', './build/**/*.css'])
+    .pipe(gzip())
+    .pipe(gulp.dest(function(file) { return file.base }))
+})
+
 gulp.task('watch', function () {
   gulp.watch('./lib/**/*.less', ['heim-less'])
   gulp.watch('./res/**/*', ['heim-less'])
@@ -165,5 +174,5 @@ gulp.task('watch', function () {
   gulp.watch('./static/**/*', ['heim-static', 'embed-static'])
 })
 
-gulp.task('build', ['heim-js', 'raven-js', 'embed-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html'])
+gulp.task('build', ['build-statics', 'gzip'])
 gulp.task('default', ['raven-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html', 'watch', 'heim-watchify', 'embed-watchify'])

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -159,9 +159,10 @@ function watchifyTask(name, bundler, outFile, dest) {
 watchifyTask('heim-watchify', heimBundler, 'main.js', heimDest)
 watchifyTask('embed-watchify', embedBundler, 'embed.js', embedDest)
 
-gulp.task('build-statics', ['heim-js', 'raven-js', 'embed-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html'])
+gulp.task('build-statics', ['raven-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html'])
+gulp.task('build-browserify', ['heim-js', 'embed-js'])
 
-gulp.task('gzip', ['build-statics'], function() {
+gulp.task('gzip', ['build-statics', 'build-browserify'], function() {
   return gulp.src(['./build/**/*.js', './build/**/*.js.map', './build/**/*.css'])
     .pipe(gzip())
     .pipe(gulp.dest(function(file) { return file.base }))
@@ -174,5 +175,5 @@ gulp.task('watch', function () {
   gulp.watch('./static/**/*', ['heim-static', 'embed-static'])
 })
 
-gulp.task('build', ['build-statics', 'gzip'])
-gulp.task('default', ['raven-js', 'heim-less', 'heim-static', 'embed-static', 'heim-html', 'embed-html', 'watch', 'heim-watchify', 'embed-watchify'])
+gulp.task('build', ['build-statics', 'build-browserify', 'gzip'])
+gulp.task('default', ['build-statics', 'watch', 'heim-watchify', 'embed-watchify'])

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -150,6 +150,8 @@ function watchifyTask(name, bundler, outFile, dest) {
         })
         .pipe(source(outFile))
         .pipe(gulp.dest(dest))
+        .pipe(gzip())
+        .pipe(gulp.dest(dest))
     }
 
     return rebundle()

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "gulp-util": "~3.0.1",
     "vinyl-source-stream": "~0.1.1",
     "vinyl-buffer": "~1.0.0",
+    "gulp-gzip": "~1.1.0",
     "gulp-less": "~1.3.3",
     "gulp-autoprefixer": "~2.1.0",
     "gulp-uglify": "~1.0.2",


### PR DESCRIPTION
How's this look?

Though we have a valid Content-Length available, [`http.serveContent`](http://golang.org/src/net/http/fs.go?s=3521:3625#L249) is a jerk and unsets it for us. Any ideas on how to work around this? I was playing with setting `r.ContentLength`, but that didn't work. I've also considered getting really hacky and making my own `ResponseWriter`. :(

:eyeglasses: @logan 