### PR TITLE
Add monitoring for expired messages

### DIFF
--- a/backend/mock/room.go
+++ b/backend/mock/room.go
@@ -266,6 +266,11 @@ func (r *memRoom) UnbanIP(ctx scope.Context, ip string) error {
 	return nil
 }
 
+func (r *memRoom) IsValidParent(id snowflake.Snowflake) (bool, error) {
+	// TODO: actually check log to see if it is valid.
+	return true, nil
+}
+
 type roomKey struct {
 	id        string
 	timestamp time.Time

--- a/backend/psql/migrations/009-room-retention-time.sql
+++ b/backend/psql/migrations/009-room-retention-time.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE room ADD retention_days INT DEFAULT 0;
+
+-- +migrate Down
+ALTER TABLE room DROP IF EXISTS retention_days;

--- a/backend/session.go
+++ b/backend/session.go
@@ -507,7 +507,13 @@ func (s *session) handleSendCommand(cmd *proto.SendCommand) (interface{}, error)
 		return nil, err
 	}
 
-	// TODO: verify parent
+	isValidParent, err := s.room.IsValidParent(cmd.Parent)
+	if err != nil {
+		return nil, err
+	}
+	if !isValidParent {
+		return nil, proto.ErrInvalidParent
+	}
 	msg := proto.Message{
 		ID:      msgID,
 		Content: cmd.Content,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,22 @@ presence:
     HEIM_CONFIG: /go/src/euphoria.io/heim/heim.yml
   command: run.sh heimctl presence-exporter -http :80 -interval 10s
 
+retention:
+  build: backend
+  links:
+    - etcd
+    - psql
+  volumes:
+    - .:/go/src/euphoria.io/heim
+    - deps/godeps:/godeps
+  ports:
+    - "8082:80"
+  environment:
+    HEIM_ETCD: http://etcd:4001
+    HEIM_ETCD_HOME: /dev/euphoria.io
+    HEIM_CONFIG: /go/src/euphoria.io/heim/heim.yml
+  command: run.sh heimctl log-retention -http :80 -interval 10s
+
 activity:
   build: backend
   links:

--- a/heimctl/cmd/retention.go
+++ b/heimctl/cmd/retention.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"euphoria.io/heim/heimctl/retention"
+	"euphoria.io/scope"
+)
+
+func init() {
+	register("log-retention", &retentionCmd{})
+}
+
+type retentionCmd struct {
+	addr     string
+	interval time.Duration
+}
+
+func (retentionCmd) desc() string {
+	return "start up the service to delete expired messages."
+}
+
+func (retentionCmd) usage() string {
+	return "log-retention [--http=<interface:port>] [--interval=DURATION]"
+}
+
+func (retentionCmd) longdesc() string {
+	return `
+	Start the service that deletes expired messages. This is a service that 
+	polls the postgres db for messages sent longer than the per-room retention
+	duration and deletes them.
+`[1:]
+}
+
+func (cmd *retentionCmd) flags() *flag.FlagSet {
+	flags := flag.NewFlagSet("log-retention", flag.ExitOnError)
+	flags.StringVar(&cmd.addr, "http", ":8080", "address to serve metrics on")
+	flags.DurationVar(&cmd.interval, "interval", 60*time.Second, "sleep interval between presence table scans")
+	return flags
+}
+
+func (cmd *retentionCmd) run(ctx scope.Context, args []string) error {
+	c, err := getCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	b, err := getBackend(ctx, c)
+	if err != nil {
+		return fmt.Errorf("backend error: %s", err)
+	}
+	defer b.Close()
+
+	defer func() {
+		ctx.Cancel()
+		ctx.WaitGroup().Wait()
+	}()
+
+	// start metrics server
+	ctx.WaitGroup().Add(1)
+	go retention.Serve(ctx, cmd.addr)
+
+	// start metrics scanner
+	ctx.WaitGroup().Add(1)
+	retention.ExpiredScanLoop(ctx, c, b, cmd.interval)
+
+	return nil
+}

--- a/heimctl/retention/metrics.go
+++ b/heimctl/retention/metrics.go
@@ -1,0 +1,22 @@
+package retention
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	roomHasExpiredMsg = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "room_has_expired",
+		Subsystem: "retention",
+		Help:      "Whether a room has expired messages, labeled by room name.",
+	}, []string{"room"})
+
+	lastExpiredScan = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "last_expired_scan",
+		Subsystem: "retention",
+		Help:      "The last Unix time the expired message scanner loop completed.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(roomHasExpiredMsg)
+	prometheus.MustRegister(lastExpiredScan)
+}

--- a/heimctl/retention/scanner.go
+++ b/heimctl/retention/scanner.go
@@ -1,0 +1,82 @@
+package retention
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"euphoria.io/heim/backend/cluster"
+	"euphoria.io/heim/backend/psql"
+	"euphoria.io/scope"
+)
+
+const (
+	maxErrors   = 3
+	GracePeriod = time.Hour
+)
+
+func scanForExpired(ctx scope.Context, c cluster.Cluster, pb *psql.Backend) error {
+	rows, err := pb.DbMap.Select(
+		psql.Room{},
+		"SELECT name, founded_by, retention_days FROM room WHERE retention_days > 0")
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		room, ok := row.(*psql.Room)
+		if !ok {
+			fmt.Printf("error: expected row of type *psql.Room, got %T\n", row)
+			continue
+		}
+		var oldestRow struct {
+			Oldest time.Time
+		}
+		err := pb.DbMap.SelectOne(&oldestRow,
+			"SELECT Min(posted) AS oldest FROM message WHERE room = $1",
+			room.Name)
+		// no rows => no expired messages
+		if err == sql.ErrNoRows {
+			roomHasExpiredMsg.With(prometheus.Labels{"room": room.Name}).Set(0)
+			continue
+		}
+		if err != nil {
+			fmt.Printf("error selecting oldest message: %s\n", err)
+			continue
+		}
+		threshold := time.Now().Add(time.Duration(-room.RetentionDays)*24*time.Hour - GracePeriod)
+		if oldestRow.Oldest.Before(threshold) {
+			roomHasExpiredMsg.With(prometheus.Labels{"room": room.Name}).Set(1)
+		} else {
+			roomHasExpiredMsg.With(prometheus.Labels{"room": room.Name}).Set(0)
+		}
+		lastExpiredScan.Set(float64(time.Now().Unix()))
+	}
+	return nil
+}
+
+func ExpiredScanLoop(ctx scope.Context, c cluster.Cluster, pb *psql.Backend, interval time.Duration) {
+	defer ctx.WaitGroup().Done()
+
+	errCount := 0
+	for {
+		t := time.After(interval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-t:
+			if err := scanForExpired(ctx, c, pb); err != nil {
+				errCount++
+				fmt.Printf("scan error [%d/%d]: %s", errCount, maxErrors, err)
+				if errCount > maxErrors {
+					fmt.Println("maximum scan errors exceeded, terminating")
+					ctx.Terminate(fmt.Errorf("maximum scan errors exceeded"))
+					return
+				}
+				continue
+			}
+			errCount = 0
+		}
+	}
+}

--- a/heimctl/retention/server.go
+++ b/heimctl/retention/server.go
@@ -1,0 +1,45 @@
+package retention
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"euphoria.io/scope"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func Serve(ctx scope.Context, addr string) {
+	http.Handle("/metrics", prometheus.Handler())
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		ctx.Terminate(err)
+	}
+
+	closed := false
+	m := sync.Mutex{}
+	closeListener := func() {
+		m.Lock()
+		if !closed {
+			listener.Close()
+			closed = true
+		}
+		m.Unlock()
+	}
+
+	// Spin off goroutine to watch ctx and close listener if shutdown requested.
+	go func() {
+		<-ctx.Done()
+		closeListener()
+	}()
+
+	if err := http.Serve(listener, nil); err != nil {
+		fmt.Printf("http[%s]: %s\n", addr, err)
+		ctx.Terminate(err)
+	}
+
+	closeListener()
+	ctx.WaitGroup().Done()
+}

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrInvalidNick      = fmt.Errorf("invalid nick")
 	ErrMessageNotFound  = fmt.Errorf("message not found")
 	ErrEditInconsistent = fmt.Errorf("edit inconsistent")
+	ErrInvalidParent    = fmt.Errorf("invalid parent ID")
 )

--- a/proto/room.go
+++ b/proto/room.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"euphoria.io/heim/proto/security"
+	"euphoria.io/heim/proto/snowflake"
 	"euphoria.io/scope"
 )
 
@@ -79,6 +80,9 @@ type Room interface {
 	// GetCapability retrieves the capability under the given ID, or
 	// returns nil if it doesn't exist.
 	GetCapability(ctx scope.Context, id string) (security.Capability, error)
+
+	// IsValidParent checks whether the message with the given ID is able to be replied to.
+	IsValidParent(id snowflake.Snowflake) (bool, error)
 }
 
 type RoomKey interface {


### PR DESCRIPTION
This pull request does a few things, but mainly adds a subcommand in heimctl that starts a loop to monitor whether each room has messages older than the per-room expiration time.

To facilitate this, a column has been added to the room table to keep track of how many days to keep messages. The default value of 0 means that messages do not expire.

Additionally, incoming send commands' parent IDs are checked to ensure that the parent exists and is not expired.