### PR TITLE
Subcommand scanners need to add to the context waitgroup

### DIFF
--- a/heimctl/cmd/activity.go
+++ b/heimctl/cmd/activity.go
@@ -63,6 +63,7 @@ func (cmd *activityCmd) run(ctx scope.Context, args []string) error {
 	go activity.Serve(ctx, cmd.addr)
 
 	// Start scanner.
+	ctx.WaitGroup().Add(1)
 	activity.ScanLoop(ctx, listener)
 
 	return nil

--- a/heimctl/cmd/presence.go
+++ b/heimctl/cmd/presence.go
@@ -65,6 +65,7 @@ func (cmd *presenceCmd) run(ctx scope.Context, args []string) error {
 	go presence.Serve(ctx, cmd.addr)
 
 	// Start scanner.
+	ctx.WaitGroup().Add(1)
 	presence.ScanLoop(ctx, c, b, cmd.interval)
 
 	return nil


### PR DESCRIPTION
Currently, the activity and presence scanners defer waitgroup.Done() but there is no corresponding waitgroup.Add(1). Consequently, upon a call of waitgroup.Wait() the call will finish when all but one of the waitgroup tasks are complete.