### PR TITLE
Add complete, auto-generated packet documentation.

### DIFF
--- a/backend/console/handler.go
+++ b/backend/console/handler.go
@@ -81,7 +81,7 @@ func (c *console) resolveAccount(ctx scope.Context, ref string) (proto.Account, 
 
 type consoleIdentity console
 
-func (c *consoleIdentity) ID() string       { return "console" }
+func (c *consoleIdentity) ID() proto.UserID { return proto.UserID("console") }
 func (c *consoleIdentity) Name() string     { return "console" }
 func (c *consoleIdentity) ServerID() string { return "" }
 

--- a/backend/identity.go
+++ b/backend/identity.go
@@ -17,14 +17,14 @@ func newMemIdentity(id, serverID, serverEra string) *memIdentity {
 	}
 }
 
-func (s *memIdentity) ID() string        { return s.id }
+func (s *memIdentity) ID() proto.UserID  { return proto.UserID(s.id) }
 func (s *memIdentity) Name() string      { return s.name }
 func (s *memIdentity) ServerID() string  { return s.serverID }
 func (s *memIdentity) ServerEra() string { return s.serverEra }
 
 func (s *memIdentity) View() *proto.IdentityView {
 	return &proto.IdentityView{
-		ID:        s.id,
+		ID:        proto.UserID(s.id),
 		Name:      s.name,
 		ServerID:  s.serverID,
 		ServerEra: s.serverEra,

--- a/backend/integration_tests.go
+++ b/backend/integration_tests.go
@@ -231,7 +231,7 @@ func (tc *testConn) expect(id, cmdType, data string, args ...interface{}) {
 	if packetType == proto.SnapshotEventType {
 		snapshot := payload.(*proto.SnapshotEvent)
 		tc.sessionID = snapshot.SessionID
-		tc.userID = snapshot.Identity
+		tc.userID = string(snapshot.Identity)
 		snapshot.SessionID = "???"
 		snapshot.Identity = "???"
 	}
@@ -411,8 +411,11 @@ func testBroadcast(s *serverUnderTest) {
 			conn.expectSnapshot(s.backend.Version(), listingParts, nil)
 			me := conn.id()
 			ids[i] = proto.SessionView{
-				SessionID:    conn.sessionID,
-				IdentityView: &proto.IdentityView{ID: me, Name: fmt.Sprintf("user%d", i)},
+				SessionID: conn.sessionID,
+				IdentityView: &proto.IdentityView{
+					ID:   proto.UserID(me),
+					Name: fmt.Sprintf("user%d", i),
+				},
 			}
 			listingParts = append(listingParts,
 				fmt.Sprintf(
@@ -495,7 +498,7 @@ func testThreading(s *serverUnderTest) {
 
 		id := &proto.SessionView{
 			SessionID:    conn.sessionID,
-			IdentityView: &proto.IdentityView{ID: conn.id(), Name: conn.id()},
+			IdentityView: &proto.IdentityView{ID: proto.UserID(conn.id()), Name: conn.id()},
 		}
 		sfs := snowflakes(2)
 		sf1 := sfs[0]

--- a/backend/mock/room.go
+++ b/backend/mock/room.go
@@ -21,8 +21,8 @@ type memRoom struct {
 	log        *memLog
 	agentBans  map[string]time.Time
 	ipBans     map[string]time.Time
-	identities map[string]proto.Identity
-	live       map[string][]proto.Session
+	identities map[proto.UserID]proto.Identity
+	live       map[proto.UserID][]proto.Session
 
 	sec        *proto.RoomSecurity
 	messageKey *roomMessageKey
@@ -124,10 +124,10 @@ func (r *memRoom) Join(ctx scope.Context, session proto.Session) error {
 	defer r.m.Unlock()
 
 	if r.identities == nil {
-		r.identities = map[string]proto.Identity{}
+		r.identities = map[proto.UserID]proto.Identity{}
 	}
 	if r.live == nil {
-		r.live = map[string][]proto.Session{}
+		r.live = map[proto.UserID][]proto.Session{}
 	}
 
 	ident := session.Identity()

--- a/backend/mock/room_test.go
+++ b/backend/mock/room_test.go
@@ -33,9 +33,9 @@ func TestRoomPresence(t *testing.T) {
 	Convey("First join", t, func() {
 		So(room.Join(ctx, userA), ShouldBeNil)
 		So(room.identities, ShouldResemble,
-			map[string]proto.Identity{"A": userA.Identity()})
+			map[proto.UserID]proto.Identity{"A": userA.Identity()})
 		So(room.live, ShouldResemble,
-			map[string][]proto.Session{"A": []proto.Session{userA}})
+			map[proto.UserID][]proto.Session{"A": []proto.Session{userA}})
 	})
 
 	Convey("Second join", t, func() {

--- a/backend/psql/listener.go
+++ b/backend/psql/listener.go
@@ -46,8 +46,8 @@ func (lm ListenerMap) Broadcast(ctx scope.Context, event *proto.Packet, exclude 
 	fastKeepaliveAgentID := ""
 	if event.Type == proto.JoinEventType {
 		if presence, ok := payload.(*proto.PresenceEvent); ok {
-			if idx := strings.IndexRune(presence.ID, '-'); idx >= 0 {
-				fastKeepaliveAgentID = presence.ID[:idx]
+			if idx := strings.IndexRune(string(presence.ID), '-'); idx >= 1 {
+				fastKeepaliveAgentID = string(presence.ID[:idx])
 			}
 		}
 		for _, sessionID := range exclude {

--- a/backend/psql/message.go
+++ b/backend/psql/message.go
@@ -40,7 +40,7 @@ func NewMessage(
 	}
 	if sessionView != nil {
 		msg.SessionID = sessionView.SessionID
-		msg.SenderID = sessionView.ID
+		msg.SenderID = string(sessionView.ID)
 		msg.SenderName = sessionView.Name
 		msg.ServerID = sessionView.ServerID
 		msg.ServerEra = sessionView.ServerEra
@@ -59,7 +59,7 @@ func (m *Message) ToBackend() proto.Message {
 		UnixTime: proto.Time(m.Posted),
 		Sender: &proto.SessionView{
 			IdentityView: &proto.IdentityView{
-				ID:        m.SenderID,
+				ID:        proto.UserID(m.SenderID),
 				Name:      m.SenderName,
 				ServerID:  m.ServerID,
 				ServerEra: m.ServerEra,

--- a/backend/psql/presence.go
+++ b/backend/psql/presence.go
@@ -45,21 +45,21 @@ type roomConn struct {
 
 type roomPresence map[string]roomConn
 
-func (rp roomPresence) load(sessionID, userID, nick string) {
-	rc, ok := rp[userID]
+func (rp roomPresence) load(sessionID string, userID proto.UserID, nick string) {
+	rc, ok := rp[string(userID)]
 	if !ok {
 		rc = roomConn{
 			sessions: map[string]proto.Session{},
 			nicks:    map[string]string{},
 		}
-		rp[userID] = rc
+		rp[string(userID)] = rc
 	}
 	rc.nicks[sessionID] = nick
 }
 
 func (rp roomPresence) join(session proto.Session) {
 	rp.load(session.ID(), session.Identity().ID(), session.Identity().Name())
-	rp[session.Identity().ID()].sessions[session.ID()] = session
+	rp[string(session.Identity().ID())].sessions[session.ID()] = session
 }
 
 func (rp roomPresence) part(session proto.Session) { delete(rp, session.ID()) }
@@ -93,13 +93,13 @@ func (rp roomPresence) broadcast(ctx scope.Context, event *proto.Packet, exclude
 }
 
 func (rp roomPresence) rename(nickEvent *proto.NickEvent) {
-	rc, ok := rp[nickEvent.ID]
+	rc, ok := rp[string(nickEvent.ID)]
 	if !ok {
 		rc = roomConn{
 			sessions: map[string]proto.Session{},
 			nicks:    map[string]string{},
 		}
-		rp[nickEvent.ID] = rc
+		rp[string(nickEvent.ID)] = rc
 	}
 
 	for _, session := range rc.sessions {

--- a/backend/psql/room.go
+++ b/backend/psql/room.go
@@ -190,7 +190,7 @@ func (rb *RoomBinding) EditMessage(
 	// TODO: tests pass in a nil session, until we add support for the edit command
 	if session != nil {
 		entry.EditorID = sql.NullString{
-			String: session.Identity().ID(),
+			String: string(session.Identity().ID()),
 			Valid:  true,
 		}
 	}

--- a/backend/session.go
+++ b/backend/session.go
@@ -483,7 +483,7 @@ func (s *session) handleCommand(cmd *proto.Packet) *response {
 		return &response{packet: &proto.PingReply{UnixTime: msg.UnixTime}}
 	case *proto.PingReply:
 		s.finishFastKeepalive()
-		if msg.UnixTime == s.expectedPingReply {
+		if time.Time(msg.UnixTime).Unix() == s.expectedPingReply {
 			s.outstandingPings = 0
 		} else if s.outstandingPings > 1 {
 			s.outstandingPings--
@@ -1080,8 +1080,8 @@ func (s *session) sendPing() error {
 	logger := Logger(s.ctx)
 	now := time.Now()
 	cmd, err := proto.MakeEvent(&proto.PingEvent{
-		UnixTime:     now.Unix(),
-		NextUnixTime: now.Add(3 * KeepAlive / 2).Unix(),
+		UnixTime:     proto.Time(now),
+		NextUnixTime: proto.Time(now.Add(3 * KeepAlive / 2)),
 	})
 	if err != nil {
 		logger.Printf("error: ping event: %s", err)

--- a/doc/api.md
+++ b/doc/api.md
@@ -84,7 +84,8 @@ is in reply to.
 Here is an example [send](#send) command sent from a client to the server:
 
 ```
-{"id": "1",
+{
+ "id": "1",
  "type": "send",
  "data": {
   "content": "hello world!"
@@ -95,7 +96,8 @@ Here is an example [send](#send) command sent from a client to the server:
 In response, the server will send back a [send-reply](#send):
 
 ```
-{"id": "1",
+{
+ "id": "1",
  "type": "send-reply",
  "data": {
   "id": "00gd6yy9hvksg",
@@ -116,7 +118,8 @@ The server will also send a [send-event](#send-event) to all the other sessions 
 to the same room:
 
 ```
-{"type": "send-event",
+{
+ "type": "send-event",
  "data": {
   "id": "00gd6yy9hvksg",
   "time": 1418585715,
@@ -138,7 +141,8 @@ When a client connects to the websocket for a room, the server will begin the se
 with a [ping-event](#ping-event):
 
 ```
-{"type": "ping-event",
+{
+ "type": "ping-event",
  "data": {
   "time": 1428979816,
   "next": 1428979846
@@ -149,7 +153,8 @@ with a [ping-event](#ping-event):
 The client should immediately reply with the same timestamp:
 
 ```
-{"type": "ping-reply",
+{
+ "type": "ping-reply",
  "data": {
   "time": 1428979816
  }

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,108 +1,1089 @@
-Packets
-=======
+# Table of Contents
 
-The heim API is transmitted via websocket in units called *packets*. Each packet is serialized to JSON with UTF-8 encoding for transmission.
+* [Overview](#overview)
+* [Field Types](#field-types)
+* [Commands and Replies](#commands-and-replies)
+  * [Session Management](#session-management)
+    * [auth](#auth)
+    * [ping](#ping)
+  * [Chat Room Commands](#chat-room-commands)
+    * [log](#log)
+    * [nick](#nick)
+    * [send](#send)
+    * [who](#who)
+  * [Account Management](#account-management)
+    * [login](#login)
+    * [logout](#logout)
+    * [register-account](#register-account)
+  * [Room Manager Commands](#room-manager-commands)
+    * [edit-message](#edit-message)
+    * [grant-access](#grant-access)
+    * [grant-manager](#grant-manager)
+    * [revoke-access](#revoke-access)
+    * [revoke-manager](#revoke-manager)
+  * [Staff Commands](#staff-commands)
+    * [staff-create-room](#staff-create-room)
+    * [staff-grant-manager](#staff-grant-manager)
+    * [staff-lock-room](#staff-lock-room)
+    * [staff-revoke-access](#staff-revoke-access)
+    * [staff-revoke-manager](#staff-revoke-manager)
+    * [staff-upgrade-room](#staff-upgrade-room)
+    * [unlock-staff-capability](#unlock-staff-capability)
+* [Asynchronous Events](#asynchronous-events)
+  * [bounce-event](#bounce-event)
+  * [disconnect-event](#disconnect-event)
+  * [edit-message-event](#edit-message-event)
+  * [join-event](#join-event)
+  * [network-event](#network-event)
+  * [nick-event](#nick-event)
+  * [part-event](#part-event)
+  * [ping-event](#ping-event)
+  * [send-event](#send-event)
+  * [snapshot-event](#snapshot-event)
 
-Packets originating from the client will always receive a packet from the server in response. If a client sends packets A and B, then the server will always send the response to A before it sends the response to B.
+# Overview
 
-The server may also send packets to the client asynchronously. For example, when a user says something in a room, a packet is broadcast to each other session connected to that room. An asynchronous packet could be transmitted before the response to a client packet is transmitted.
+Clients interact with Euphoria over a WebSocket-based API. The connection is to a specific
+*room*. We call each instance of such a connection a *session*.
 
-Every packet shares a common top-level structure. Here is an example packet sent by the client when a user says something in a room:
+## Packets
+
+Messages are sent back and forth between the client and server as packets, in the form of JSON objects.
+Each packet has the following structure:
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [string](#string) | *optional* |  client-generated id for associating replies with commands |
+| `type` | [PacketType](#packettype) | required |  the name of the command, reply, or event |
+| `data` | object | *optional* |  the payload of the command, reply, or event |
+| `error` | [string](#string) | *optional* |  this field appears in replies if a command fails |
+| `throttled` | [bool](#bool) | *optional* |  this field appears in replies to warn the client that it may be flooding; the client should slow down its command rate |
+| `throttled_reason` | [string](#string) | *optional* |  if throttled is true, this field describes why |
+
+
+
+
+The `type` field determines the type of the `data` field. Packet types come in three flavors:
+
+1. *Commands*. These names have no suffix. Examples: "[ping](#ping)", "[send](#send)"
+2. *Replies*. Every command type has a corresponding reply type. Their names all have a `-reply` suffix. Examples: "[ping-reply](#ping)", "[send-reply](#send)"
+3. *Events*. These names all have an `-event` suffix. Examples: "[snapshot-event](#snapshot-event)", "[ping-event](#ping-event)"
+
+Almost all client-to-server packets must be commands. The only exception is [ping-reply](#ping),
+which the client should send in response to a [ping-event](#ping-event) from the server.
+Any other reply or event sent by the client will have an error reply sent back in response.
+
+All server-to-client packets must be either replies or events. All replies must correspond to a command
+sent by the client. The server must never send more than one reply to a command.
+
+When a client sends a command, it can choose to specify an `id`. This is an arbitrary string that
+the server will include in its reply. This helps asynchronous clients identify which command a packet
+is in reply to.
+
+Here is an example [send](#send) command sent from a client to the server:
+
+```
+{"id": "1",
+ "type": "send",
+ "data": {
+  "content": "hello world!"
+ }
+}
+```
+
+In response, the server will send back a [send-reply](#send):
+
+```
+{"id": "1",
+ "type": "send-reply",
+ "data": {
+  "id": "00gd6yy9hvksg",
+  "time": 1418585715,
+  "sender": {
+   "id": "agent:4da8fa7375215589",
+   "name": "logan",
+   "server_id": "heim.1",
+   "server_era": "00g5fdwjzl91c",
+   "session_id": "4da8fa7375215589-00000246"
+  },
+  "content": "hello world!"
+ }
+}
+```
+
+The server will also send a [send-event](#send-event) to all the other sessions connected
+to the same room:
+
+```
+{"type": "send-event",
+ "data": {
+  "id": "00gd6yy9hvksg",
+  "time": 1418585715,
+  "sender": {
+   "id": "agent:4da8fa7375215589",
+   "name": "logan",
+   "server_id": "heim.1",
+   "server_era": "00g5fdwjzl91c",
+   "session_id": "4da8fa7375215589-00000246"
+  },
+  "content": "hello world!"
+ }
+}
+```
+
+## Initial Handshake
+
+When a client connects to the websocket for a room, the server will begin the session
+with a [ping-event](#ping-event):
+
+```
+{"type": "ping-event",
+ "data": {
+  "time": 1428979816,
+  "next": 1428979846
+ }
+}
+```
+
+The client should immediately reply with the same timestamp:
+
+```
+{"type": "ping-reply",
+ "data": {
+  "time": 1428979816
+ }
+}
+```
+
+Once the client replies to the ping, one of two possible events will be sent next.
+If the room is a public room, or if the client is logged into an account that has
+been granted access to the room, then the server will send a [snapshot-event](#snapshot-event):
 
 ```
 {
-  id: "1",
-  type: "send",
+  type: "snapshot-event",
   data: {
-    content: "hello ezzie!"
+    identity: "agent:4da8fa7375215589",
+    session_id: "4da8fa7375215589-00000246",
+    version: "801ea89a4e410b11410eb61c91971439904e66c0",
+    listing: [...],
+    log:[...]
   }
 }
 ```
 
-The `id`, `type`, and `data` fields are common to all packets. The `id` *should* be given in any packet sent by the client, and its value *should* be unique in the lifetime of the connection. The server *must* include the same `id` when it sends the corresponding response packet, if an `id` was given. Asynchronous packets from the server *must not* include an `id`.
+This event serves to fill the client in on recent room history, and lists all the sessions
+currently joined in the room. From this point on, the session is *joined* with the room. A
+joined session may use chat commands and will receive room events.
 
-The `type` field specifies the command or event being communicated, and this determines the expected structure of the `data` field.
+If the room is private and the client does not have access, the server will send a
+[bounce-event](#bounce-event) instead. At this point the client should obtain the
+proper authentication credentials from the user and present them with the [auth](#auth)
+or [login](#login) command.
 
-Client Commands
-===============
+# Field Types
 
-The following commands are available to the client:
+This section describes all the field types one can expect to see in packets.
 
-| Type | Purpose | Example |
-| ----: | :------- | :------- |
-| `nick` | Modify the user's display name for this session. | 
-| `who` | Receive a listing of live users in the room. |
-| `log` | Receive the most recent chat history. |
-| `send` | Send a message to the room's chat. |
+### bool
 
-<h4>nick</h4>
+A boolean value: `true` or `false`.
 
-Use the nick command to change the user's display name, for subsequent messages sent from the user and for subsequent listings of the room.
+### int
 
-Request: `{id: "1", type: "nick", data: {name: "Ezzie"}}`
+A signed 64-bit integer value.
 
-Response: `{id: "1", type: "nick", data: {id: "logan", name: "Ezzie"}}`
+### string
 
-The response will also be broadcast to all other users in the room.
+Strings are UTF-8 encoded text. Unless otherwise specified, a string may be of any length.
 
-Broadcast: `{type: "nick", data: {id: "logan", name: "Ezzie", from: "Logan"}}`
+### object
 
-<h4>who</h4>
+An arbitrary JSON object.
 
-Use the who command to fetch the current list of live users in the room.
+### AuthOption
 
-Request: `{id: "1", type: "who"}`
+`AuthOption` is a string indicating a mode of authentication. It must be one of the
+following values:
 
-Response: `{id: "1", type: "who", data: [{id: "logan", name: "Logan"}, {id: "chromakode", name: "Max"}]}
+| Value | Description |
+| :-- | :--------- |
+| `passcode` | Authentication with a passcode, where a key is derived from the passcode to unlock an access grant. |
 
-<h4>log</h4>
+### Message
 
-Use the log command to fetch the latest *n* messages from the room's chat.
+A Message is a node in a Room's Log. It corresponds to a chat message, or
+a post, or any broadcasted event in a room that should appear in the log.
 
-Request: `{id: "1", type: "log", data: {n: 50}}`
 
-Response:
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [Snowflake](#snowflake) | required |  the id of the message (unique within a room) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the id of the message's parent, or null if top-level |
+| `previous_edit_id` | [Snowflake](#snowflake) | *optional* |  the edit id of the most recent edit of this message, or null if it's never been edited |
+| `time` | [Time](#time) | required |  the unix timestamp of when the message was posted |
+| `sender` | [SessionView](#sessionview) | required |  the view of the sender's session |
+| `content` | [string](#string) | required |  the content of the message (client-defined) |
+| `encryption_key_id` | [string](#string) | *optional* |  the id of the key that encrypts the message in storage |
+| `edited` | [Time](#time) | *optional* |  the unix timestamp of when the message was last edited |
+| `deleted` | [Time](#time) | *optional* |  the unix timestamp of when the message was deleted |
 
-```
-{
-  id: "1",
-  type: "log",
-  data: [
-    {time: 1418585692, sender: {id: "chromakode", name: "Max"}, content: "hi!"},
-    {time: 1418585697, sender: {id: "logan", name: "Logan"}, content: "j0!"}
-  ]
-}
-```
 
-<h4>send</h4>
 
-Use the send command to send a message to the room's chat.
 
-Request: `{id: "1", type: "send", data: {content: "hello ezzie"}}`
+### PacketType
 
-Response:
-```
-{
-  id: "1",
-  type: "send",
-  data: {
-    time: 1418585715,
-    sender: {id: "logan", name: "Logan"},
-    content: "hello ezzie"
-  }
-}
-```
+`PacketType` is a string describing the type of the packet. For example, "[ping](#ping)",
+"[ping-reply](#ping-reply)", and "[ping-event](#ping-event)" are packet types.
 
-The response will also be broadcast to all other users in the room.
+### SessionView
 
-Broadcast:
-```
-{
-  type: "send",
-  data: {
-    time: 1418585715,
-    sender: {id: "logan", name: "Logan"},
-    content: "hello ezzie"
-  }
-}
-```
+SessionView describes a session and its identity.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [UserID](#userid) | required |  the id of an agent or account |
+| `name` | [string](#string) | required |  the name-in-use at the time this view was captured |
+| `server_id` | [string](#string) | required |  the id of the server that captured this view |
+| `server_era` | [string](#string) | required |  the era of the server that captured this view |
+| `session_id` | [string](#string) | required |  id of the session, unique across all sessions globally |
+
+
+
+
+### Snowflake
+
+A snowflake is a 13-character string, usually used as a unique identifier for some type
+of object. It is the base-36 encoding of an unsigned, 64-bit integer.
+
+### Time
+
+Time is specified as a signed 64-bit integer, giving the number of seconds since the Unix Epoch.
+
+### UserID
+
+A UserID identifies a user. The prefix of this value (up to the colon) indicates a type of session,
+while the suffix is a unique value for that type of session.
+
+| Prefix | Suffix | Description |
+| :-- | :-- | :----- |
+| `agent:` | *agent identifier* | A user, not signed into any account, but tracked via cookie under this identifier. |
+| `account:` | *account identifier* | The id ([Snowflake](#snowflake)) of the account the user is logged into. |
+
+# Commands and Replies
+
+As described in the [Overview](#overview), there are a number of commands that the
+client may send to the server. For each such command, there is a corresponding reply
+that the server will send in return.
+
+## Session Management
+
+Session management commands are involved in the initial handshake and maintenance of a session.
+
+### auth
+
+The `auth` command attempts to join a private room. It should be sent in response
+to a `bounce-event` at the beginning of a session.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `type` | [AuthOption](#authoption) | required |  the method of authentication |
+| `passcode` | [string](#string) | *optional* |  use this field for `passcode` authentication |
+
+
+
+
+
+The `auth-reply` packet reports whether the `auth` command succeeded.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `success` | [bool](#bool) | required |  true if authentication succeeded |
+| `reason` | [string](#string) | *optional* |  if `success` was false, the reason for failure |
+
+
+
+
+
+
+
+### ping
+
+The `ping` command initiates a client-to-server ping. The server will send
+back a `ping-reply` with the same timestamp as soon as possible.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `time` | [Time](#time) | required |  an arbitrary value, intended to be a unix timestamp |
+
+
+
+
+
+`ping-reply` is a response to a `ping` command or `ping-event`.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `time` | [Time](#time) | *optional* |  the timestamp of the ping being replied to |
+
+
+
+
+
+
+
+## Chat Room Commands
+
+These commands are available to the client once a session successfully joins a room.
+
+### log
+
+The `log` command requests messages from the room's message log. This can be used
+to supplement the log provided by `snapshot-event` (for example, when scrolling
+back further in history).
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `n` | [int](#int) | required |  maximum number of messages to return (up to 1000) |
+| `before` | [Snowflake](#snowflake) | *optional* |  return messages prior to this snowflake |
+
+
+
+
+
+The `log-reply` packet returns a list of messages from the room's message log.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `log` | [[Message](#message)] | required |  list of messages returned |
+| `before` | [Snowflake](#snowflake) | *optional* |  messages prior to this snowflake were returned |
+
+
+
+
+
+
+
+### nick
+
+The `nick` command sets the name you present to the room. This name applies
+to all messages sent during this session, until the `nick` command is called
+again.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `name` | [string](#string) | required |  the requested name (maximum length 36 bytes) |
+
+
+
+
+
+`nick-reply` confirms the `nick` command. It returns the session's former
+and new names (the server may modify the requested nick).
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `session_id` | [string](#string) | required |  the id of the session this name applies to |
+| `id` | [UserID](#userid) | required |  the id of the agent or account logged into the session |
+| `from` | [string](#string) | required |  the previous name associated with the session |
+| `to` | [string](#string) | required |  the name associated with the session henceforth |
+
+
+
+
+
+
+
+### send
+
+The `send` command sends a message to a room. The session must be
+successfully joined with the room. This message will be broadcast to
+all sessions joined with the room.
+
+If the room is private, then the message content will be encrypted
+before it is stored and broadcast to the rest of the room.
+
+The caller of this command will not receive the corresponding
+`send-event`, but will receive the same information in the `send-reply`.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `content` | [string](#string) | required |  the content of the message (client-defined) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the id of the parent message, if any |
+
+
+
+
+
+`send-reply` returns the message that was sent. This includes the message id,
+which was populated by the server.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [Snowflake](#snowflake) | required |  the id of the message (unique within a room) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the id of the message's parent, or null if top-level |
+| `previous_edit_id` | [Snowflake](#snowflake) | *optional* |  the edit id of the most recent edit of this message, or null if it's never been edited |
+| `time` | [Time](#time) | required |  the unix timestamp of when the message was posted |
+| `sender` | [SessionView](#sessionview) | required |  the view of the sender's session |
+| `content` | [string](#string) | required |  the content of the message (client-defined) |
+| `encryption_key_id` | [string](#string) | *optional* |  the id of the key that encrypts the message in storage |
+| `edited` | [Time](#time) | *optional* |  the unix timestamp of when the message was last edited |
+| `deleted` | [Time](#time) | *optional* |  the unix timestamp of when the message was deleted |
+
+
+
+
+
+
+
+### who
+
+The `who` command requests a list of sessions currently joined in the room.
+
+
+The `who-reply` packet lists the sessions currently joined in the room.
+
+
+This packet has no fields.
+
+
+
+## Account Management
+
+These commands enable a client to register, associate, and dissociate with an account.
+An account allows an identity to be shared across browsers and devices, and is a
+prerequisite for room management.
+
+### login
+
+The `login` command attempts to log an anonymous session into an account.
+It will return an error if the session is already logged in.
+
+If the login succeeds, the client should expect to receive a
+`disconnect-event` shortly after. The next connection the client makes
+will be a logged in session.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `namespace` | [string](#string) | required |  the namespace of a personal identifier |
+| `id` | [string](#string) | required |  the id of a personal identifier |
+| `password` | [string](#string) | required |  the password for unlocking the account |
+
+
+
+
+
+The `login-reply` packet returns whether the session successfully logged
+into an account.
+
+If this reply returns success, the client should expect to receive a
+`disconnect-event` shortly after. The next connection the client makes
+will be a logged in session.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `success` | [bool](#bool) | required |  true if the session is now logged in |
+| `reason` | [string](#string) | required |  if `success` was false, the reason why |
+| `account_id` | [Snowflake](#snowflake) | required |  if `success` was true, the id of the account the session logged into. |
+
+
+
+
+
+
+
+### logout
+
+The `logout` command logs a session out of an account. It will return an error
+if the session is not logged in.
+
+If the logout is successful, the client should expect to receive a
+`disconnect-event` shortly after. The next connection the client
+makes will be a logged out session.
+
+
+This packet has no fields.
+
+
+
+
+The `logout-reply` packet confirms a logout.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### register-account
+
+The `register-account` command creates a new account and logs into it.
+It will return an error if the session is already logged in.
+
+If the account registration succeeds, the client should expect to receive a
+`disconnect-event` shortly after. The next connection the client makes will be
+a logged in session using the new account.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `namespace` | [string](#string) | required |  the namespace of a personal identifier |
+| `id` | [string](#string) | required |  the id of a personal identifier |
+| `password` | [string](#string) | required |  the password for unlocking the account |
+
+
+
+
+
+The `register-account-reply` packet returns whether the new account was
+registered.
+
+If this reply returns success, the client should expect to receive a
+disconnect-event shortly after. The next connection the client makes
+will be a logged in session, using the newly created account.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `success` | [bool](#bool) | required |  true if the session is now logged in |
+| `reason` | [string](#string) | required |  if `success` was false, the reason why |
+| `account_id` | [Snowflake](#snowflake) | required |  if `success` was true, the id of the account the session logged into. |
+
+
+
+
+
+
+
+## Room Manager Commands
+
+These commands are available if the client is logged into an account that has a manager grant
+on the room.
+
+### edit-message
+
+The `edit-message` command can be used by active room managers to modify the
+content or display of a message.
+
+A message deleted by this command is still stored in the database. Deleted
+messages may be undeleted by this command. (Messages that have expired from
+the database due to the room's retention policy are no longer available and
+cannot be restored by this or any command).
+
+If the `announce` field is set to true, then an edit-message-event will be
+broadcast to the room.
+
+TODO: support content editing
+TODO: support reparenting
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [Snowflake](#snowflake) | required |  the id of the message to edit |
+| `previous_edit_id` | [Snowflake](#snowflake) | required |  the `previous_edit_id` of the message; if this does not match, the edit will fail (basic conflict resolution) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the new parent of the message (*not yet implemented*) |
+| `content` | [string](#string) | *optional* |  the new content of the message (*not yet implemented*) |
+| `delete` | [bool](#bool) | required |  the new deletion status of the message |
+| `announce` | [bool](#bool) | required |  if true, broadcast an `edit-message-event` to the room |
+
+
+
+
+
+`edit-message-reply` returns the id of a successful edit.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `edit_id` | [Snowflake](#snowflake) | required |  the unique id of the edit that was applied |
+| `deleted` | [bool](#bool) | *optional* |  the new deletion status of the edited message |
+
+
+
+
+
+
+
+### grant-access
+
+The `grant-access` command may be used by an active manager in a private room
+to create a new capability for access. Access may be granted to either a
+passcode or an account.
+
+If the room is not private, or if the requested access grant already exists,
+an error will be returned.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | *optional* |  the id of an account to grant access to |
+| `passcode` | [string](#string) | *optional* |  a passcode to grant access to; anyone presenting the same passcode can access the room |
+
+
+
+
+
+`grant-access-reply` confirms that access was granted.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### grant-manager
+
+The `grant-manager` command may be used by an active room manager to make
+another account a manager in the same room.
+
+An error is returned if the account can't be found.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | required |  the id of an account to grant manager status to |
+
+
+
+
+
+`grant-manager-reply` confirms that manager status was granted.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### revoke-access
+
+The `revoke-access` command disables an access grant to a private room.
+The grant may be to an account or to a passcode.
+
+TODO: all live sessions using the revoked grant should be disconnected
+TODO: support revocation by capability_id, in case a manager doesn't know the passcode
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | *optional* |  the id of the account to revoke access from |
+| `passcode` | [string](#string) | required |  the passcode to revoke access from |
+
+
+
+
+
+`revoke-access-reply` confirms that the access grant was revoked.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### revoke-manager
+
+The `revoke-manager` command removes an account as manager of the room.
+This command can be applied to oneself, so be careful not to orphan
+your room!
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | required |  the id of the account to remove as manager |
+
+
+
+
+
+`revoke-manager-reply` confirms that the manager grant was revoked.
+
+
+This packet has no fields.
+
+
+
+
+
+
+## Staff Commands
+
+Staff commands are only available to site operators. This section is not relevant to
+most client implementations.
+
+### staff-create-room
+
+The `staff-create-room` command creates a new room.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `name` | [string](#string) | required |  the name of the new rom |
+| `managers` | [[Snowflake](#snowflake)] | required |  ids of manager accounts for this room (there must be at least one) |
+| `private` | [bool](#bool) | *optional* |  if true, create a private room (all managers will be granted access) |
+
+
+
+
+
+`staff-create-room-reply` returns the outcome of a room creation request.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `success` | [bool](#bool) | required |  whether the room was created |
+| `failure_reason` | [string](#string) | *optional* |  if `success` was false, the reason why |
+
+
+
+
+
+
+
+### staff-grant-manager
+
+The `staff-grant-manager` command is a version of the [grant-manager](#grant-manager)
+command that is available to staff. The staff account does not need to be a manager
+of the room to use this command.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | required |  the id of an account to grant manager status to |
+
+
+
+
+
+`staff-grant-manager-reply` confirms that requested manager change was granted.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### staff-lock-room
+
+The `staff-lock-room` command makes a room private. If the room is already private,
+then it generates a new message key (which currently invalidates all access grants).
+
+
+This packet has no fields.
+
+
+
+
+`staff-lock-room-reply` confirms that the room has been made newly private.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### staff-revoke-access
+
+The `staff-revoke-access` command is a version of the [revoke-access](#revoke-access)
+command that is available to staff. The staff account does not need to be a manager
+of the room to use this command.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | *optional* |  the id of the account to revoke access from |
+| `passcode` | [string](#string) | required |  the passcode to revoke access from |
+
+
+
+
+
+`staff-revoke-access-reply` confirms that requested access capability was revoked.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### staff-revoke-manager
+
+The `staff-revoke-manager` command is a version of the [revoke-manager](#revoke-access)
+command that is available to staff. The staff account does not need to be a manager
+of the room to use this command.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `account_id` | [Snowflake](#snowflake) | required |  the id of the account to remove as manager |
+
+
+
+
+
+`staff-revoke-manager-reply` confirms that requested manager capability was revoked.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### staff-upgrade-room
+
+The `staff-upgrade-room` command generates keys and nonces for a room that existed
+before accounts were rolled out.
+
+
+This packet has no fields.
+
+
+
+
+`staff-upgrade-room-reply` confirms that the room was upgraded.
+
+
+This packet has no fields.
+
+
+
+
+
+
+### unlock-staff-capability
+
+The `unlock-staff-capability` command may be called by a staff account to gain access to
+staff commands.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `password` | [string](#string) | required |  the account's password |
+
+
+
+
+
+`unlock-staff-capability-reply` returns the outcome of unlocking the staff
+capability.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `success` | [bool](#bool) | required |  whether staff capability was unlocked |
+| `failure_reason` | [string](#string) | *optional* |  if `success` was false, the reason why |
+
+
+
+
+
+
+
+# Asynchronous Events
+
+The following events may be sent from the server to the client at any time.
+
+## bounce-event
+
+A `bounce-event` indicates that access to a room is denied.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `reason` | [string](#string) | *optional* |  the reason why access was denied |
+| `auth_options` | [[AuthOption](#authoption)] | *optional* |  authentication options that may be used; see [auth](#auth) |
+| `agent_id` | [string](#string) | *optional* |  internal use only |
+| `ip` | [string](#string) | *optional* |  internal use only |
+
+
+
+
+## disconnect-event
+
+A `disconnect-event` indicates that the session is being closed. The client
+will subsequently be disconnected.
+
+If the disconnect reason is "authentication changed", the client should
+immediately reconnect.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `reason` | [string](#string) | required |  the reason for disconnection |
+
+
+
+
+## join-event
+
+A join-event indicates a session just joined the room.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [UserID](#userid) | required |  the id of an agent or account |
+| `name` | [string](#string) | required |  the name-in-use at the time this view was captured |
+| `server_id` | [string](#string) | required |  the id of the server that captured this view |
+| `server_era` | [string](#string) | required |  the era of the server that captured this view |
+| `session_id` | [string](#string) | required |  id of the session, unique across all sessions globally |
+
+
+
+
+## network-event
+
+A `network-event` indicates some server-side event that impacts the presence
+of sessions in a room.
+
+If the network event type is `partition`, then this should be treated as
+a [part-event](#part-event) for all sessions connected to the same server
+id/era combo.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `type` | [string](#string) | required |  the type of network event; for now, always `partition` |
+| `server_id` | [string](#string) | required |  the id of the affected server |
+| `server_era` | [string](#string) | required |  the era of the affected server |
+
+
+
+
+## nick-event
+
+`nick-event` announces a nick change by another session in the room.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `session_id` | [string](#string) | required |  the id of the session this name applies to |
+| `id` | [UserID](#userid) | required |  the id of the agent or account logged into the session |
+| `from` | [string](#string) | required |  the previous name associated with the session |
+| `to` | [string](#string) | required |  the name associated with the session henceforth |
+
+
+
+
+## edit-message-event
+
+An `edit-message-event` indicates that a message in the room has been
+modified or deleted. If the client offers a user interface and the
+indicated message is currently displayed, it should update its display
+accordingly.
+
+The event packet includes a snapshot of the message post-edit.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [Snowflake](#snowflake) | required |  the id of the message (unique within a room) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the id of the message's parent, or null if top-level |
+| `previous_edit_id` | [Snowflake](#snowflake) | *optional* |  the edit id of the most recent edit of this message, or null if it's never been edited |
+| `time` | [Time](#time) | required |  the unix timestamp of when the message was posted |
+| `sender` | [SessionView](#sessionview) | required |  the view of the sender's session |
+| `content` | [string](#string) | required |  the content of the message (client-defined) |
+| `encryption_key_id` | [string](#string) | *optional* |  the id of the key that encrypts the message in storage |
+| `edited` | [Time](#time) | *optional* |  the unix timestamp of when the message was last edited |
+| `deleted` | [Time](#time) | *optional* |  the unix timestamp of when the message was deleted |
+| `edit_id` | [Snowflake](#snowflake) | required |  the id of the edit |
+
+
+
+
+## part-event
+
+A part-event indicates a session just disconnected from the room.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [UserID](#userid) | required |  the id of an agent or account |
+| `name` | [string](#string) | required |  the name-in-use at the time this view was captured |
+| `server_id` | [string](#string) | required |  the id of the server that captured this view |
+| `server_era` | [string](#string) | required |  the era of the server that captured this view |
+| `session_id` | [string](#string) | required |  id of the session, unique across all sessions globally |
+
+
+
+
+## ping-event
+
+A `ping-event` represents a server-to-client ping. The client should send back
+a `ping-reply` with the same value for the time field as soon as possible
+(or risk disconnection).
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `time` | [Time](#time) | required |  a unix timestamp according to the server's clock |
+| `next` | [Time](#time) | required |  the expected time of the next ping-event, according to the server's clock |
+
+
+
+
+## send-event
+
+A `send-event` indicates a message received by the room from another session.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `id` | [Snowflake](#snowflake) | required |  the id of the message (unique within a room) |
+| `parent` | [Snowflake](#snowflake) | *optional* |  the id of the message's parent, or null if top-level |
+| `previous_edit_id` | [Snowflake](#snowflake) | *optional* |  the edit id of the most recent edit of this message, or null if it's never been edited |
+| `time` | [Time](#time) | required |  the unix timestamp of when the message was posted |
+| `sender` | [SessionView](#sessionview) | required |  the view of the sender's session |
+| `content` | [string](#string) | required |  the content of the message (client-defined) |
+| `encryption_key_id` | [string](#string) | *optional* |  the id of the key that encrypts the message in storage |
+| `edited` | [Time](#time) | *optional* |  the unix timestamp of when the message was last edited |
+| `deleted` | [Time](#time) | *optional* |  the unix timestamp of when the message was deleted |
+
+
+
+
+## snapshot-event
+
+A `snapshot-event` indicates that a session has successfully joined a room.
+It also offers a snapshot of the room's state and recent history.
+
+
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+| `identity` | [UserID](#userid) | required |  the id of the agent or account logged into this session |
+| `session_id` | [string](#string) | required |  the globally unique id of this session |
+| `version` | [string](#string) | required |  the server's version identifier |
+| `listing` | [[SessionView](#sessionview)] | required |  the list of all other sessions joined to the room (excluding this session) |
+| `log` | [[Message](#message)] | required |  the most recent messages posted to the room (currently up to 100) |
+
+
+

--- a/doc/gen/api.md
+++ b/doc/gen/api.md
@@ -73,7 +73,8 @@ is in reply to.
 Here is an example [send](#send) command sent from a client to the server:
 
 ```
-{"id": "1",
+{
+ "id": "1",
  "type": "send",
  "data": {
   "content": "hello world!"
@@ -84,7 +85,8 @@ Here is an example [send](#send) command sent from a client to the server:
 In response, the server will send back a [send-reply](#send):
 
 ```
-{"id": "1",
+{
+ "id": "1",
  "type": "send-reply",
  "data": {
   "id": "00gd6yy9hvksg",
@@ -105,7 +107,8 @@ The server will also send a [send-event](#send-event) to all the other sessions 
 to the same room:
 
 ```
-{"type": "send-event",
+{
+ "type": "send-event",
  "data": {
   "id": "00gd6yy9hvksg",
   "time": 1418585715,
@@ -127,7 +130,8 @@ When a client connects to the websocket for a room, the server will begin the se
 with a [ping-event](#ping-event):
 
 ```
-{"type": "ping-event",
+{
+ "type": "ping-event",
  "data": {
   "time": 1428979816,
   "next": 1428979846
@@ -138,7 +142,8 @@ with a [ping-event](#ping-event):
 The client should immediately reply with the same timestamp:
 
 ```
-{"type": "ping-reply",
+{
+ "type": "ping-reply",
  "data": {
   "time": 1428979816
  }

--- a/doc/gen/api.md
+++ b/doc/gen/api.md
@@ -1,0 +1,408 @@
+# Table of Contents
+
+* [Overview](#overview)
+* [Field Types](#field-types)
+* [Commands and Replies](#commands-and-replies)
+  * [Session Management](#session-management)
+    * [auth](#auth)
+    * [ping](#ping)
+  * [Chat Room Commands](#chat-room-commands)
+    * [log](#log)
+    * [nick](#nick)
+    * [send](#send)
+    * [who](#who)
+  * [Account Management](#account-management)
+    * [login](#login)
+    * [logout](#logout)
+    * [register-account](#register-account)
+  * [Room Manager Commands](#room-manager-commands)
+    * [edit-message](#edit-message)
+    * [grant-access](#grant-access)
+    * [grant-manager](#grant-manager)
+    * [revoke-access](#revoke-access)
+    * [revoke-manager](#revoke-manager)
+  * [Staff Commands](#staff-commands)
+    * [staff-create-room](#staff-create-room)
+    * [staff-grant-manager](#staff-grant-manager)
+    * [staff-lock-room](#staff-lock-room)
+    * [staff-revoke-access](#staff-revoke-access)
+    * [staff-revoke-manager](#staff-revoke-manager)
+    * [staff-upgrade-room](#staff-upgrade-room)
+    * [unlock-staff-capability](#unlock-staff-capability)
+* [Asynchronous Events](#asynchronous-events)
+  * [bounce-event](#bounce-event)
+  * [disconnect-event](#disconnect-event)
+  * [edit-message-event](#edit-message-event)
+  * [join-event](#join-event)
+  * [network-event](#network-event)
+  * [nick-event](#nick-event)
+  * [part-event](#part-event)
+  * [ping-event](#ping-event)
+  * [send-event](#send-event)
+  * [snapshot-event](#snapshot-event)
+
+# Overview
+
+Clients interact with Euphoria over a WebSocket-based API. The connection is to a specific
+*room*. We call each instance of such a connection a *session*.
+
+## Packets
+
+Messages are sent back and forth between the client and server as packets, in the form of JSON objects.
+Each packet has the following structure:
+
+{{template "fields.md" (object "Packet")}}
+
+The `type` field determines the type of the `data` field. Packet types come in three flavors:
+
+1. *Commands*. These names have no suffix. Examples: "[ping](#ping)", "[send](#send)"
+2. *Replies*. Every command type has a corresponding reply type. Their names all have a `-reply` suffix. Examples: "[ping-reply](#ping)", "[send-reply](#send)"
+3. *Events*. These names all have an `-event` suffix. Examples: "[snapshot-event](#snapshot-event)", "[ping-event](#ping-event)"
+
+Almost all client-to-server packets must be commands. The only exception is [ping-reply](#ping),
+which the client should send in response to a [ping-event](#ping-event) from the server.
+Any other reply or event sent by the client will have an error reply sent back in response.
+
+All server-to-client packets must be either replies or events. All replies must correspond to a command
+sent by the client. The server must never send more than one reply to a command.
+
+When a client sends a command, it can choose to specify an `id`. This is an arbitrary string that
+the server will include in its reply. This helps asynchronous clients identify which command a packet
+is in reply to.
+
+Here is an example [send](#send) command sent from a client to the server:
+
+```
+{"id": "1",
+ "type": "send",
+ "data": {
+  "content": "hello world!"
+ }
+}
+```
+
+In response, the server will send back a [send-reply](#send):
+
+```
+{"id": "1",
+ "type": "send-reply",
+ "data": {
+  "id": "00gd6yy9hvksg",
+  "time": 1418585715,
+  "sender": {
+   "id": "agent:4da8fa7375215589",
+   "name": "logan",
+   "server_id": "heim.1",
+   "server_era": "00g5fdwjzl91c",
+   "session_id": "4da8fa7375215589-00000246"
+  },
+  "content": "hello world!"
+ }
+}
+```
+
+The server will also send a [send-event](#send-event) to all the other sessions connected
+to the same room:
+
+```
+{"type": "send-event",
+ "data": {
+  "id": "00gd6yy9hvksg",
+  "time": 1418585715,
+  "sender": {
+   "id": "agent:4da8fa7375215589",
+   "name": "logan",
+   "server_id": "heim.1",
+   "server_era": "00g5fdwjzl91c",
+   "session_id": "4da8fa7375215589-00000246"
+  },
+  "content": "hello world!"
+ }
+}
+```
+
+## Initial Handshake
+
+When a client connects to the websocket for a room, the server will begin the session
+with a [ping-event](#ping-event):
+
+```
+{"type": "ping-event",
+ "data": {
+  "time": 1428979816,
+  "next": 1428979846
+ }
+}
+```
+
+The client should immediately reply with the same timestamp:
+
+```
+{"type": "ping-reply",
+ "data": {
+  "time": 1428979816
+ }
+}
+```
+
+Once the client replies to the ping, one of two possible events will be sent next.
+If the room is a public room, or if the client is logged into an account that has
+been granted access to the room, then the server will send a [snapshot-event](#snapshot-event):
+
+```
+{
+  type: "snapshot-event",
+  data: {
+    identity: "agent:4da8fa7375215589",
+    session_id: "4da8fa7375215589-00000246",
+    version: "801ea89a4e410b11410eb61c91971439904e66c0",
+    listing: [...],
+    log:[...]
+  }
+}
+```
+
+This event serves to fill the client in on recent room history, and lists all the sessions
+currently joined in the room. From this point on, the session is *joined* with the room. A
+joined session may use chat commands and will receive room events.
+
+If the room is private and the client does not have access, the server will send a
+[bounce-event](#bounce-event) instead. At this point the client should obtain the
+proper authentication credentials from the user and present them with the [auth](#auth)
+or [login](#login) command.
+
+# Field Types
+
+This section describes all the field types one can expect to see in packets.
+
+### bool
+
+A boolean value: `true` or `false`.
+
+### int
+
+A signed 64-bit integer value.
+
+### string
+
+Strings are UTF-8 encoded text. Unless otherwise specified, a string may be of any length.
+
+### object
+
+An arbitrary JSON object.
+
+### AuthOption
+
+`AuthOption` is a string indicating a mode of authentication. It must be one of the
+following values:
+
+| Value | Description |
+| :-- | :--------- |
+| `passcode` | Authentication with a passcode, where a key is derived from the passcode to unlock an access grant. |
+
+### Message
+
+{{(object "Message").Doc}}
+{{template "fields.md" (object "Message")}}
+
+### PacketType
+
+`PacketType` is a string describing the type of the packet. For example, "[ping](#ping)",
+"[ping-reply](#ping-reply)", and "[ping-event](#ping-event)" are packet types.
+
+### SessionView
+
+{{(object "SessionView").Doc}}
+{{template "fields.md" (object "SessionView")}}
+
+### Snowflake
+
+A snowflake is a 13-character string, usually used as a unique identifier for some type
+of object. It is the base-36 encoding of an unsigned, 64-bit integer.
+
+### Time
+
+Time is specified as a signed 64-bit integer, giving the number of seconds since the Unix Epoch.
+
+### UserID
+
+A UserID identifies a user. The prefix of this value (up to the colon) indicates a type of session,
+while the suffix is a unique value for that type of session.
+
+| Prefix | Suffix | Description |
+| :-- | :-- | :----- |
+| `agent:` | *agent identifier* | A user, not signed into any account, but tracked via cookie under this identifier. |
+| `account:` | *account identifier* | The id ([Snowflake](#snowflake)) of the account the user is logged into. |
+
+# Commands and Replies
+
+As described in the [Overview](#overview), there are a number of commands that the
+client may send to the server. For each such command, there is a corresponding reply
+that the server will send in return.
+
+## Session Management
+
+Session management commands are involved in the initial handshake and maintenance of a session.
+
+### auth
+
+{{template "command.md" "auth"}}
+
+### ping
+
+{{template "command.md" "ping"}}
+
+## Chat Room Commands
+
+These commands are available to the client once a session successfully joins a room.
+
+### log
+
+{{template "command.md" "log"}}
+
+### nick
+
+{{template "command.md" "nick"}}
+
+### send
+
+{{template "command.md" "send"}}
+
+### who
+
+{{(packet "who").Doc}}
+
+{{(packet "who-reply").Doc}}
+{{template "fields.md" (packet "who-reply")}}
+
+## Account Management
+
+These commands enable a client to register, associate, and dissociate with an account.
+An account allows an identity to be shared across browsers and devices, and is a
+prerequisite for room management.
+
+### login
+
+{{template "command.md" "login"}}
+
+### logout
+
+{{template "command.md" "logout"}}
+
+### register-account
+
+{{template "command.md" "register-account"}}
+
+## Room Manager Commands
+
+These commands are available if the client is logged into an account that has a manager grant
+on the room.
+
+### edit-message
+
+{{template "command.md" "edit-message"}}
+
+### grant-access
+
+{{template "command.md" "grant-access"}}
+
+### grant-manager
+
+{{template "command.md" "grant-manager"}}
+
+### revoke-access
+
+{{template "command.md" "revoke-access"}}
+
+### revoke-manager
+
+{{template "command.md" "revoke-manager"}}
+
+## Staff Commands
+
+Staff commands are only available to site operators. This section is not relevant to
+most client implementations.
+
+### staff-create-room
+
+{{template "command.md" "staff-create-room"}}
+
+### staff-grant-manager
+
+{{template "command.md" "staff-grant-manager"}}
+
+### staff-lock-room
+
+{{template "command.md" "staff-lock-room"}}
+
+### staff-revoke-access
+
+{{template "command.md" "staff-revoke-access"}}
+
+### staff-revoke-manager
+
+{{template "command.md" "staff-revoke-manager"}}
+
+### staff-upgrade-room
+
+{{template "command.md" "staff-upgrade-room"}}
+
+### unlock-staff-capability
+
+{{template "command.md" "unlock-staff-capability"}}
+
+# Asynchronous Events
+
+The following events may be sent from the server to the client at any time.
+
+## bounce-event
+
+{{(packet "bounce-event").Doc}}
+{{template "fields.md" (packet "bounce-event")}}
+
+## disconnect-event
+
+{{(packet "disconnect-event").Doc}}
+{{template "fields.md" (packet "disconnect-event")}}
+
+## join-event
+
+A join-event indicates a session just joined the room.
+
+{{template "fields.md" (object "PresenceEvent")}}
+
+## network-event
+
+{{(packet "network-event").Doc}}
+{{template "fields.md" (packet "network-event")}}
+
+## nick-event
+
+{{(packet "nick-event").Doc}}
+{{template "fields.md" (packet "nick-event")}}
+
+## edit-message-event
+
+{{(packet "edit-message-event").Doc}}
+{{template "fields.md" (packet "edit-message-event")}}
+
+## part-event
+
+A part-event indicates a session just disconnected from the room.
+
+{{template "fields.md" (object "PresenceEvent")}}
+
+## ping-event
+
+{{(packet "ping-event").Doc}}
+{{template "fields.md" (packet "ping-event")}}
+
+## send-event
+
+{{(packet "send-event").Doc}}
+{{template "fields.md" (packet "send-event")}}
+
+## snapshot-event
+
+{{(packet "snapshot-event").Doc}}
+{{template "fields.md" (packet "snapshot-event")}}

--- a/doc/gen/command.md
+++ b/doc/gen/command.md
@@ -1,0 +1,2 @@
+{{template "packet.md" .}}
+{{template "packet.md" (printf "%s-reply" .)}}

--- a/doc/gen/fields.md
+++ b/doc/gen/fields.md
@@ -1,0 +1,8 @@
+{{if gt (len .Fields) 0}}
+| Field | Type | Required? | Description |
+| :-- | :-- | :-- | :--------- |
+{{range .Fields}}| `{{.Name}}` | {{linkType .TypeName}} | {{if .Optional}}*optional*{{else}}required{{end}} | {{.Comments}} |
+{{end}}
+{{else}}
+This packet has no fields.
+{{end}}

--- a/doc/gen/gen.go
+++ b/doc/gen/gen.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"euphoria.io/heim/proto"
+)
+
+type objects doc.Package
+
+func (o *objects) tmplObject(name string) (command, error) {
+	for _, typ := range o.Types {
+		if typ.Name == name {
+			cmd := command{
+				Name: name,
+				Doc:  typ.Doc,
+			}
+
+			if len(typ.Decl.Specs) > 0 {
+				if ts, ok := typ.Decl.Specs[0].(*ast.TypeSpec); ok {
+					cmd.Fields = getFields(o, ts.Type)
+				}
+			}
+
+			return cmd, nil
+		}
+	}
+
+	return command{}, fmt.Errorf("object not found: %s", name)
+}
+
+type packets map[string]command
+
+func (ps packets) tmplPacket(name string) (command, error) {
+	if cmd, ok := ps[name]; ok {
+		cmd.Displayed = true
+		ps[name] = cmd
+		return cmd, nil
+	}
+	return command{}, fmt.Errorf("packet not found: %s", name)
+}
+
+func (ps packets) tmplOthers() []command {
+	commands := []command{}
+	for _, cmd := range ps {
+		if !cmd.Displayed && cmd.Name != "PresenceEvent" {
+			commands = append(commands, cmd)
+		}
+	}
+	sort.Sort(commandList(commands))
+	return commands
+}
+
+type types map[string]string
+
+func (types) link(name string) string { return strings.ToLower(name) }
+
+func (t types) registerType(name string) string {
+	t[name] = t.link(name)
+	return ""
+}
+
+func (t types) linkType(name string) string {
+	switch {
+	case strings.HasPrefix(name, "[]"):
+		return fmt.Sprintf("[%s]", t.linkType(name[2:]))
+	case name == "Listing":
+		return t.linkType("[]SessionView")
+	case name == "snowflake.Snowflake":
+		return t.linkType("Snowflake")
+	case name == "json.RawMessage":
+		return "object"
+	default:
+		if link, ok := t[name]; ok {
+			return fmt.Sprintf("[%s](#%s)", name, link)
+		}
+		fmt.Fprintf(os.Stderr, "undocumented field type: %s\n", name)
+		return fmt.Sprintf("`%s`", name)
+	}
+}
+
+type command struct {
+	Name      string
+	Doc       string
+	Fields    []field
+	Displayed bool
+}
+
+type commandList []command
+
+func (cl commandList) Len() int           { return len(cl) }
+func (cl commandList) Less(i, j int) bool { return cl[i].Name < cl[j].Name }
+func (cl commandList) Swap(i, j int)      { cl[i], cl[j] = cl[j], cl[i] }
+
+type field struct {
+	Name     string
+	TypeName string
+	Optional bool
+	Comments string
+}
+
+func sortObjects(obs *objects) packets {
+	ps := packets{}
+	for commandName, typeName := range proto.PacketsByType() {
+		cmd, err := obs.tmplObject(typeName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: resolve error: %s\n", err)
+			continue
+		}
+		ps[string(commandName)] = cmd
+	}
+	return ps
+}
+
+func getFields(obs *objects, node ast.Node) []field {
+	switch typ := node.(type) {
+	case *ast.StructType:
+		fields := make([]field, 0, len(typ.Fields.List))
+		for _, f := range typ.Fields.List {
+			if len(f.Names) == 0 {
+				// embedded type
+				expr := f.Type
+				for {
+					if subexpr, ok := expr.(*ast.StarExpr); ok {
+						expr = subexpr.X
+						continue
+					}
+					break
+				}
+				switch ft := expr.(type) {
+				case *ast.Ident:
+					fields = append(fields, getFields(obs, ft)...)
+				default:
+					fmt.Fprintf(os.Stderr, "skipping field: %#v\n", f)
+				}
+				continue
+			}
+			nf := field{
+				TypeName: typeIdent(f.Type),
+				Comments: joinComments(f.Comment),
+			}
+			nf.Name, nf.Optional = nameAndOptional(f)
+			fields = append(fields, nf)
+		}
+		return fields
+	case *ast.Ident:
+		for _, t := range obs.Types {
+			if t.Name == typ.Name {
+				if len(t.Decl.Specs) > 0 {
+					if ts, ok := t.Decl.Specs[0].(*ast.TypeSpec); ok {
+						return getFields(obs, ts.Type)
+					}
+				}
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func typeIdent(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", typeIdent(t.X), t.Sel.Name)
+	case *ast.StarExpr:
+		return typeIdent(t.X)
+	case *ast.ArrayType:
+		return fmt.Sprintf("[]%s", typeIdent(t.Elt))
+	default:
+		return fmt.Sprintf("%#v", expr)
+	}
+}
+
+func nameAndOptional(f *ast.Field) (string, bool) {
+	name := f.Names[0].Name
+	optional := false
+
+	if fieldTag, err := strconv.Unquote(f.Tag.Value); err == nil {
+		jsonTag := reflect.StructTag(fieldTag).Get("json")
+		parts := strings.Split(jsonTag, ",")
+		if parts[0] != "" {
+			name = parts[0]
+		}
+		for _, part := range parts[1:] {
+			if part == "omitempty" {
+				optional = true
+				break
+			}
+		}
+	}
+
+	return name, optional
+}
+
+func joinComments(cg *ast.CommentGroup) string {
+	if cg == nil {
+		return ""
+	}
+	b := &bytes.Buffer{}
+	for _, c := range cg.List {
+		text := c.Text
+		if strings.HasPrefix(text, "//") {
+			text = text[2:]
+		}
+		b.WriteString(text)
+	}
+	return b.String()
+}
+
+func run() error {
+	pkg, err := build.Import("euphoria.io/heim/proto", "", build.FindOnly)
+	if err != nil {
+		return fmt.Errorf("import error: %s", err)
+	}
+
+	if pkg.SrcRoot == "" {
+		return fmt.Errorf("error: can't find source for package euphoria.io/heim/proto")
+	}
+
+	pkgs, err := parser.ParseDir(
+		token.NewFileSet(), filepath.Join(pkg.SrcRoot, "euphoria.io/heim/proto"), nil,
+		parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse error: %s", err)
+	}
+
+	obs := (*objects)(doc.New(pkgs["proto"], "euphoria.io/heim/proto", 0))
+	ps := sortObjects(obs)
+	ts := types{}
+	t := template.New("api.md").Funcs(template.FuncMap{
+		"object": obs.tmplObject,
+		"others": ps.tmplOthers,
+		"packet": ps.tmplPacket,
+
+		"linkType":     ts.linkType,
+		"registerType": ts.registerType,
+	})
+
+	ts.registerType("bool")
+	ts.registerType("int")
+	ts.registerType("object")
+	ts.registerType("string")
+	ts.registerType("AuthOption")
+	ts.registerType("Message")
+	ts.registerType("PacketType")
+	ts.registerType("SessionView")
+	ts.registerType("Snowflake")
+	ts.registerType("Time")
+	ts.registerType("UserID")
+
+	gendir := filepath.Join(pkg.SrcRoot, "euphoria.io/heim/doc/gen")
+	if err := os.Chdir(gendir); err != nil {
+		return fmt.Errorf("chdir error: %s: %s", gendir, err)
+	}
+
+	if _, err := t.ParseGlob("*.md"); err != nil {
+		return fmt.Errorf("template parse error: %s", err)
+	}
+	if err := t.Execute(os.Stdout, nil); err != nil {
+		return fmt.Errorf("template render error: %s", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/doc/gen/packet.md
+++ b/doc/gen/packet.md
@@ -1,0 +1,3 @@
+{{with (packet .)}}{{.Doc}}
+{{template "fields.md" .}}
+{{end}}

--- a/proto/identity.go
+++ b/proto/identity.go
@@ -20,20 +20,22 @@ const (
 	bidiIsolatePop  = '\u2069'
 )
 
+type UserID string
+
 // An Identity maps to a global persona. It may exist only in the context
 // of a single Room. An Identity may be anonymous.
 type Identity interface {
-	ID() string
+	ID() UserID
 	Name() string
 	ServerID() string
 	View() *IdentityView
 }
 
 type IdentityView struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	ServerID  string `json:"server_id"`
-	ServerEra string `json:"server_era"`
+	ID        UserID `json:"id"`         // the id of an agent or account
+	Name      string `json:"name"`       // the name-in-use at the time this view was captured
+	ServerID  string `json:"server_id"`  // the id of the server that captured this view
+	ServerEra string `json:"server_era"` // the era of the server that captured this view
 }
 
 // NormalizeNick validates and normalizes a proposed name from a user.

--- a/proto/message.go
+++ b/proto/message.go
@@ -9,15 +9,15 @@ import (
 // A Message is a node in a Room's Log. It corresponds to a chat message, or
 // a post, or any broadcasted event in a room that should appear in the log.
 type Message struct {
-	ID              snowflake.Snowflake `json:"id"`
-	Parent          snowflake.Snowflake `json:"parent"`
-	PreviousEditID  snowflake.Snowflake `json:"previous_edit_id,omitempty"`
-	UnixTime        Time                `json:"time"`
-	Sender          *SessionView        `json:"sender"`
-	Content         string              `json:"content"`
-	EncryptionKeyID string              `json:"encryption_key_id,omitempty"`
-	Edited          Time                `json:"edited,omitempty"`
-	Deleted         Time                `json:"deleted,omitempty"`
+	ID              snowflake.Snowflake `json:"id"`                          // the id of the message (unique within a room)
+	Parent          snowflake.Snowflake `json:"parent,omitempty"`            // the id of the message's parent, or null if top-level
+	PreviousEditID  snowflake.Snowflake `json:"previous_edit_id,omitempty"`  // the edit id of the most recent edit of this message, or null if it's never been edited
+	UnixTime        Time                `json:"time"`                        // the unix timestamp of when the message was posted
+	Sender          *SessionView        `json:"sender"`                      // the view of the sender's session
+	Content         string              `json:"content"`                     // the content of the message (client-defined)
+	EncryptionKeyID string              `json:"encryption_key_id,omitempty"` // the id of the key that encrypts the message in storage
+	Edited          Time                `json:"edited,omitempty"`            // the unix timestamp of when the message was last edited
+	Deleted         Time                `json:"deleted,omitempty"`           // the unix timestamp of when the message was deleted
 }
 
 func (msg *Message) Encode() ([]byte, error) { return json.Marshal(msg) }

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -15,7 +15,6 @@ func (c PacketType) Reply() PacketType { return c + "-reply" }
 
 var (
 	AuthType      = PacketType("auth")
-	AuthEventType = AuthType.Event()
 	AuthReplyType = AuthType.Reply()
 
 	SendType      = PacketType("send")
@@ -38,7 +37,6 @@ var (
 	PartEventType = PartType.Event()
 
 	LogType      = PacketType("log")
-	LogEventType = LogType.Event()
 	LogReplyType = LogType.Reply()
 
 	LoginType      = PacketType("login")
@@ -74,7 +72,7 @@ var (
 	StaffLockRoomReplyType = StaffLockRoomType.Reply()
 
 	StaffRevokeAccessType      = PacketType("staff-revoke-access")
-	StaffRevokeAccessReplyType = StaffRevokeManagerType.Reply()
+	StaffRevokeAccessReplyType = StaffRevokeAccessType.Reply()
 
 	StaffRevokeManagerType      = PacketType("staff-revoke-manager")
 	StaffRevokeManagerReplyType = StaffRevokeManagerType.Reply()
@@ -86,7 +84,6 @@ var (
 	UnlockStaffCapabilityReplyType = UnlockStaffCapabilityType.Reply()
 
 	WhoType      = PacketType("who")
-	WhoEventType = WhoType.Event()
 	WhoReplyType = WhoType.Reply()
 
 	BounceEventType     = PacketType("bounce").Event()
@@ -112,7 +109,6 @@ var (
 		GrantManagerReplyType: reflect.TypeOf(GrantManagerReply{}),
 
 		LogType:      reflect.TypeOf(LogCommand{}),
-		LogEventType: reflect.TypeOf(LogEvent{}),
 		LogReplyType: reflect.TypeOf(LogReply{}),
 
 		JoinEventType: reflect.TypeOf(PresenceEvent{}),
@@ -145,7 +141,6 @@ var (
 		StaffUpgradeRoomReplyType: reflect.TypeOf(StaffUpgradeRoomReply{}),
 
 		AuthType:      reflect.TypeOf(AuthCommand{}),
-		AuthEventType: reflect.TypeOf(AuthEvent{}),
 		AuthReplyType: reflect.TypeOf(AuthReply{}),
 
 		BounceEventType:     reflect.TypeOf(BounceEvent{}),
@@ -172,212 +167,368 @@ var (
 		UnlockStaffCapabilityReplyType: reflect.TypeOf(UnlockStaffCapabilityReply{}),
 
 		WhoType:      reflect.TypeOf(WhoCommand{}),
-		WhoEventType: reflect.TypeOf(WhoEvent{}),
 		WhoReplyType: reflect.TypeOf(WhoReply{}),
 	}
 )
+
+func PacketsByType() map[PacketType]string {
+	templates := map[PacketType]string{}
+	for name, templateType := range payloadMap {
+		templates[name] = templateType.Name()
+	}
+	return templates
+}
 
 type ErrorReply struct {
 	Error string `json:"error"`
 }
 
+// The `send` command sends a message to a room. The session must be
+// successfully joined with the room. This message will be broadcast to
+// all sessions joined with the room.
+//
+// If the room is private, then the message content will be encrypted
+// before it is stored and broadcast to the rest of the room.
+//
+// The caller of this command will not receive the corresponding
+// `send-event`, but will receive the same information in the `send-reply`.
 type SendCommand struct {
-	Content string              `json:"content"`
-	Parent  snowflake.Snowflake `json:"parent"`
+	Content string              `json:"content"`          // the content of the message (client-defined)
+	Parent  snowflake.Snowflake `json:"parent,omitempty"` // the id of the parent message, if any
 }
 
+// A `send-event` indicates a message received by the room from another session.
 type SendEvent Message
+
+// `send-reply` returns the message that was sent. This includes the message id,
+// which was populated by the server.
 type SendReply SendEvent
 
+// The `edit-message` command can be used by active room managers to modify the
+// content or display of a message.
+//
+// A message deleted by this command is still stored in the database. Deleted
+// messages may be undeleted by this command. (Messages that have expired from
+// the database due to the room's retention policy are no longer available and
+// cannot be restored by this or any command).
+//
+// If the `announce` field is set to true, then an edit-message-event will be
+// broadcast to the room.
+//
+// TODO: support content editing
+// TODO: support reparenting
 type EditMessageCommand struct {
-	ID             snowflake.Snowflake `json:"id"`
-	PreviousEditID snowflake.Snowflake `json:"previous_edit_id"`
-	Parent         snowflake.Snowflake `json:"parent"`
-	Content        string              `json:"content"`
-	Delete         bool                `json:"delete"`
-	Announce       bool                `json:"announce"`
+	ID             snowflake.Snowflake `json:"id"`                // the id of the message to edit
+	PreviousEditID snowflake.Snowflake `json:"previous_edit_id"`  // the `previous_edit_id` of the message; if this does not match, the edit will fail (basic conflict resolution)
+	Parent         snowflake.Snowflake `json:"parent,omitempty"`  // the new parent of the message (*not yet implemented*)
+	Content        string              `json:"content,omitempty"` // the new content of the message (*not yet implemented*)
+	Delete         bool                `json:"delete"`            // the new deletion status of the message
+	Announce       bool                `json:"announce"`          // if true, broadcast an `edit-message-event` to the room
 }
 
+// `edit-message-reply` returns the id of a successful edit.
 type EditMessageReply struct {
-	EditID  snowflake.Snowflake `json:"edit_id"`
-	Deleted bool                `json:"deleted,omitempty"`
+	EditID  snowflake.Snowflake `json:"edit_id"`           // the unique id of the edit that was applied
+	Deleted bool                `json:"deleted,omitempty"` // the new deletion status of the edited message
 }
 
+// An `edit-message-event` indicates that a message in the room has been
+// modified or deleted. If the client offers a user interface and the
+// indicated message is currently displayed, it should update its display
+// accordingly.
+//
+// The event packet includes a snapshot of the message post-edit.
 type EditMessageEvent struct {
 	Message
-	EditID snowflake.Snowflake `json:"edit_id"`
+	EditID snowflake.Snowflake `json:"edit_id"` // the id of the edit
 }
 
+// The `grant-access` command may be used by an active manager in a private room
+// to create a new capability for access. Access may be granted to either a
+// passcode or an account.
+//
+// If the room is not private, or if the requested access grant already exists,
+// an error will be returned.
 type GrantAccessCommand struct {
-	AccountID snowflake.Snowflake `json:"account_id"`
-	Passcode  string              `json:"passcode"`
+	AccountID snowflake.Snowflake `json:"account_id,omitempty"` // the id of an account to grant access to
+	Passcode  string              `json:"passcode,omitempty"`   // a passcode to grant access to; anyone presenting the same passcode can access the room
 }
 
+// `grant-access-reply` confirms that access was granted.
 type GrantAccessReply struct{}
 
+// The `grant-manager` command may be used by an active room manager to make
+// another account a manager in the same room.
+//
+// An error is returned if the account can't be found.
 type GrantManagerCommand struct {
-	AccountID snowflake.Snowflake `json:"account_id"`
+	AccountID snowflake.Snowflake `json:"account_id"` // the id of an account to grant manager status to
 }
 
+// `grant-manager-reply` confirms that manager status was granted.
 type GrantManagerReply struct{}
 
+// The `staff-grant-manager` command is a version of the [grant-manager](#grant-manager)
+// command that is available to staff. The staff account does not need to be a manager
+// of the room to use this command.
 type StaffGrantManagerCommand GrantManagerCommand
+
+// `staff-grant-manager-reply` confirms that requested manager change was granted.
 type StaffGrantManagerReply GrantManagerReply
 
+// A `presence-event` describes a session joining into or parting from a room.
 type PresenceEvent SessionView
 
+// The `log` command requests messages from the room's message log. This can be used
+// to supplement the log provided by `snapshot-event` (for example, when scrolling
+// back further in history).
 type LogCommand struct {
-	N      int                 `json:"n"`
-	Before snowflake.Snowflake `json:"before"`
+	N      int                 `json:"n"`                // maximum number of messages to return (up to 1000)
+	Before snowflake.Snowflake `json:"before,omitempty"` // return messages prior to this snowflake
 }
 
+// The `log-reply` packet returns a list of messages from the room's message log.
 type LogReply struct {
-	Log    []Message           `json:"log"`
-	Before snowflake.Snowflake `json:"before"`
+	Log    []Message           `json:"log"`              // list of messages returned
+	Before snowflake.Snowflake `json:"before,omitempty"` // messages prior to this snowflake were returned
 }
 
-type LogEvent LogReply
-
+// The `nick` command sets the name you present to the room. This name applies
+// to all messages sent during this session, until the `nick` command is called
+// again.
 type NickCommand struct {
-	Name string `json:"name"`
+	Name string `json:"name"` // the requested name (maximum length 36 bytes)
 }
 
+// `nick-reply` confirms the `nick` command. It returns the session's former
+// and new names (the server may modify the requested nick).
 type NickReply struct {
-	SessionID string `json:"session_id"`
-	ID        string `json:"id"`
-	From      string `json:"from"`
-	To        string `json:"to"`
+	SessionID string `json:"session_id"` // the id of the session this name applies to
+	ID        UserID `json:"id"`         // the id of the agent or account logged into the session
+	From      string `json:"from"`       // the previous name associated with the session
+	To        string `json:"to"`         // the name associated with the session henceforth
 }
 
+// `nick-event` announces a nick change by another session in the room.
 type NickEvent NickReply
 
+// The `ping` command initiates a client-to-server ping. The server will send
+// back a `ping-reply` with the same timestamp as soon as possible.
 type PingCommand struct {
-	UnixTime     int64 `json:"time"`
-	NextUnixTime int64 `json:"next"`
+	UnixTime Time `json:"time"` // an arbitrary value, intended to be a unix timestamp
 }
 
-type PingEvent PingCommand
+// A `ping-event` represents a server-to-client ping. The client should send back
+// a `ping-reply` with the same value for the time field as soon as possible
+// (or risk disconnection).
+type PingEvent struct {
+	UnixTime     Time `json:"time"` // a unix timestamp according to the server's clock
+	NextUnixTime Time `json:"next"` // the expected time of the next ping-event, according to the server's clock
+}
 
+// `ping-reply` is a response to a `ping` command or `ping-event`.
 type PingReply struct {
-	UnixTime int64 `json:"time,omitempty"`
+	UnixTime Time `json:"time,omitempty"` // the timestamp of the ping being replied to
 }
 
+// The `auth` command attempts to join a private room. It should be sent in response
+// to a `bounce-event` at the beginning of a session.
 type AuthCommand struct {
-	Type     AuthOption `json:"type"`
-	Passcode string     `json:"passcode,omitempty"`
+	Type     AuthOption `json:"type"`               // the method of authentication
+	Passcode string     `json:"passcode,omitempty"` // use this field for `passcode` authentication
 }
 
+// The `auth-reply` packet reports whether the `auth` command succeeded.
 type AuthReply struct {
-	Success bool   `json:"success"`
-	Reason  string `json:"reason,omitempty"`
+	Success bool   `json:"success"`          // true if authentication succeeded
+	Reason  string `json:"reason,omitempty"` // if `success` was false, the reason for failure
 }
 
-type AuthEvent AuthReply
-
+// A `bounce-event` indicates that access to a room is denied.
 type BounceEvent struct {
-	Reason      string       `json:"reason,omitempty"`
-	AuthOptions []AuthOption `json:"auth_options,omitempty"`
-	AgentID     string       `json:"agent_id,omitempty"`
-	IP          string       `json:"ip,omitempty"`
+	Reason      string       `json:"reason,omitempty"`       // the reason why access was denied
+	AuthOptions []AuthOption `json:"auth_options,omitempty"` // authentication options that may be used; see [auth](#auth)
+	AgentID     string       `json:"agent_id,omitempty"`     // internal use only
+	IP          string       `json:"ip,omitempty"`           // internal use only
 }
 
+// A `disconnect-event` indicates that the session is being closed. The client
+// will subsequently be disconnected.
+//
+// If the disconnect reason is "authentication changed", the client should
+// immediately reconnect.
 type DisconnectEvent struct {
-	Reason string `json:"reason"`
+	Reason string `json:"reason"` // the reason for disconnection
 }
 
+// A `snapshot-event` indicates that a session has successfully joined a room.
+// It also offers a snapshot of the room's state and recent history.
 type SnapshotEvent struct {
-	Identity  string    `json:"identity"`
-	SessionID string    `json:"session_id"`
-	Version   string    `json:"version"`
-	Listing   Listing   `json:"listing"`
-	Log       []Message `json:"log"`
+	Identity  UserID    `json:"identity"`   // the id of the agent or account logged into this session
+	SessionID string    `json:"session_id"` // the globally unique id of this session
+	Version   string    `json:"version"`    // the server's version identifier
+	Listing   Listing   `json:"listing"`    // the list of all other sessions joined to the room (excluding this session)
+	Log       []Message `json:"log"`        // the most recent messages posted to the room (currently up to 100)
 }
 
+// A `network-event` indicates some server-side event that impacts the presence
+// of sessions in a room.
+//
+// If the network event type is `partition`, then this should be treated as
+// a [part-event](#part-event) for all sessions connected to the same server
+// id/era combo.
 type NetworkEvent struct {
-	Type      string `json:"type"` // for now, always "partition"
-	ServerID  string `json:"server_id"`
-	ServerEra string `json:"server_era"`
+	Type      string `json:"type"`       // the type of network event; for now, always `partition`
+	ServerID  string `json:"server_id"`  // the id of the affected server
+	ServerEra string `json:"server_era"` // the era of the affected server
 }
 
+// The `login` command attempts to log an anonymous session into an account.
+// It will return an error if the session is already logged in.
+//
+// If the login succeeds, the client should expect to receive a
+// `disconnect-event` shortly after. The next connection the client makes
+// will be a logged in session.
 type LoginCommand struct {
-	Namespace string `json:"namespace"`
-	ID        string `json:"id"`
-	Password  string `json:"password"`
+	Namespace string `json:"namespace"` // the namespace of a personal identifier
+	ID        string `json:"id"`        // the id of a personal identifier
+	Password  string `json:"password"`  // the password for unlocking the account
 }
 
+// The `login-reply` packet returns whether the session successfully logged
+// into an account.
+//
+// If this reply returns success, the client should expect to receive a
+// `disconnect-event` shortly after. The next connection the client makes
+// will be a logged in session.
 type LoginReply struct {
-	Success   bool                `json:"success"`
-	Reason    string              `json:"reason"`
-	AccountID snowflake.Snowflake `json:"account_id"`
+	Success   bool                `json:"success"`    // true if the session is now logged in
+	Reason    string              `json:"reason"`     // if `success` was false, the reason why
+	AccountID snowflake.Snowflake `json:"account_id"` // if `success` was true, the id of the account the session logged into.
 }
 
+// The `logout` command logs a session out of an account. It will return an error
+// if the session is not logged in.
+//
+// If the logout is successful, the client should expect to receive a
+// `disconnect-event` shortly after. The next connection the client
+// makes will be a logged out session.
 type LogoutCommand struct{}
+
+// The `logout-reply` packet confirms a logout.
 type LogoutReply struct{}
 
+// The `register-account` command creates a new account and logs into it.
+// It will return an error if the session is already logged in.
+//
+// If the account registration succeeds, the client should expect to receive a
+// `disconnect-event` shortly after. The next connection the client makes will be
+// a logged in session using the new account.
 type RegisterAccountCommand LoginCommand
+
+// The `register-account-reply` packet returns whether the new account was
+// registered.
+//
+// If this reply returns success, the client should expect to receive a
+// disconnect-event shortly after. The next connection the client makes
+// will be a logged in session, using the newly created account.
 type RegisterAccountReply LoginReply
 
+// The `revoke-access` command disables an access grant to a private room.
+// The grant may be to an account or to a passcode.
+//
+// TODO: all live sessions using the revoked grant should be disconnected
+// TODO: support revocation by capability_id, in case a manager doesn't know the passcode
 type RevokeAccessCommand struct {
-	AccountID snowflake.Snowflake `json:"account_id"`
-	Passcode  string              `json:"passcode"`
+	AccountID snowflake.Snowflake `json:"account_id,omitempty"` // the id of the account to revoke access from
+	Passcode  string              `json:"passcode",omitempty`   // the passcode to revoke access from
 }
 
+// `revoke-access-reply` confirms that the access grant was revoked.
 type RevokeAccessReply struct{}
 
+// The `revoke-manager` command removes an account as manager of the room.
+// This command can be applied to oneself, so be careful not to orphan
+// your room!
 type RevokeManagerCommand struct {
-	AccountID snowflake.Snowflake `json:"account_id"`
+	AccountID snowflake.Snowflake `json:"account_id"` // the id of the account to remove as manager
 }
 
+// `revoke-manager-reply` confirms that the manager grant was revoked.
 type RevokeManagerReply struct{}
 
+// The `staff-create-room` command creates a new room.
 type StaffCreateRoomCommand struct {
-	Name     string                `json:"name"`
-	Managers []snowflake.Snowflake `json:"managers"`
-	Private  bool                  `json:"private,omitempty"`
+	Name     string                `json:"name"`              // the name of the new rom
+	Managers []snowflake.Snowflake `json:"managers"`          // ids of manager accounts for this room (there must be at least one)
+	Private  bool                  `json:"private,omitempty"` // if true, create a private room (all managers will be granted access)
 }
 
+// `staff-create-room-reply` returns the outcome of a room creation request.
 type StaffCreateRoomReply struct {
-	Success       bool   `json:"success"`
-	FailureReason string `json:"failure_reason,omitempty"`
+	Success       bool   `json:"success"`                  // whether the room was created
+	FailureReason string `json:"failure_reason,omitempty"` // if `success` was false, the reason why
 }
 
+// The `staff-revoke-access` command is a version of the [revoke-access](#revoke-access)
+// command that is available to staff. The staff account does not need to be a manager
+// of the room to use this command.
 type StaffRevokeAccessCommand RevokeAccessCommand
+
+// `staff-revoke-access-reply` confirms that requested access capability was revoked.
 type StaffRevokeAccessReply RevokeAccessReply
 
+// The `staff-revoke-manager` command is a version of the [revoke-manager](#revoke-access)
+// command that is available to staff. The staff account does not need to be a manager
+// of the room to use this command.
 type StaffRevokeManagerCommand RevokeManagerCommand
+
+// `staff-revoke-manager-reply` confirms that requested manager capability was revoked.
 type StaffRevokeManagerReply RevokeManagerReply
 
+// The `staff-lock-room` command makes a room private. If the room is already private,
+// then it generates a new message key (which currently invalidates all access grants).
 type StaffLockRoomCommand struct{}
+
+// `staff-lock-room-reply` confirms that the room has been made newly private.
 type StaffLockRoomReply struct{}
 
+// The `staff-upgrade-room` command generates keys and nonces for a room that existed
+// before accounts were rolled out.
 type StaffUpgradeRoomCommand struct{}
+
+// `staff-upgrade-room-reply` confirms that the room was upgraded.
 type StaffUpgradeRoomReply struct{}
 
+// The `unlock-staff-capability` command may be called by a staff account to gain access to
+// staff commands.
 type UnlockStaffCapabilityCommand struct {
-	Password string `json:"password"`
+	Password string `json:"password"` // the account's password
 }
 
+// `unlock-staff-capability-reply` returns the outcome of unlocking the staff
+// capability.
 type UnlockStaffCapabilityReply struct {
-	Success       bool   `json:"success"`
-	FailureReason string `json:"failure_reason,omitempty"`
+	Success       bool   `json:"success"`                  // whether staff capability was unlocked
+	FailureReason string `json:"failure_reason,omitempty"` // if `success` was false, the reason why
 }
 
+// The `who` command requests a list of sessions currently joined in the room.
 type WhoCommand struct{}
 
+// The `who-reply` packet lists the sessions currently joined in the room.
 type WhoReply struct {
-	Listing `json:"listing"`
+	Listing `json:"listing"` // a list of session views
 }
 
-type WhoEvent WhoReply
-
 type Packet struct {
-	ID    string          `json:"id,omitempty"`
-	Type  PacketType      `json:"type"`
-	Data  json.RawMessage `json:"data,omitempty"`
-	Error string          `json:"error,omitempty"`
+	ID    string          `json:"id,omitempty"`    // client-generated id for associating replies with commands
+	Type  PacketType      `json:"type"`            // the name of the command, reply, or event
+	Data  json.RawMessage `json:"data,omitempty"`  // the payload of the command, reply, or event
+	Error string          `json:"error,omitempty"` // this field appears in replies if a command fails
 
-	Throttled       bool   `json:"throttled,omitempty"`
-	ThrottledReason string `json:"throttled_reason,omitempty"`
+	Throttled       bool   `json:"throttled,omitempty"`        // this field appears in replies to warn the client that it may be flooding; the client should slow down its command rate
+	ThrottledReason string `json:"throttled_reason,omitempty"` // if throttled is true, this field describes why
 }
 
 func (cmd *Packet) Payload() (interface{}, error) {

--- a/proto/session.go
+++ b/proto/session.go
@@ -30,7 +30,8 @@ type Session interface {
 	View() *SessionView
 }
 
+// SessionView describes a session and its identity.
 type SessionView struct {
 	*IdentityView
-	SessionID string `json:"session_id"`
+	SessionID string `json:"session_id"` // id of the session, unique across all sessions globally
 }


### PR DESCRIPTION
Through a combination of packet.go docstrings and go's template system, we can now generate doc/api.md:

```
go run doc/gen/gen.go > doc/api.md
```