### PR TITLE
Add config option to allow unsecure cookies in dev.

### DIFF
--- a/backend/agent.go
+++ b/backend/agent.go
@@ -52,7 +52,9 @@ func (ac *agentCredentials) Cookie(sc *securecookie.SecureCookie) (*http.Cookie,
 		Path:     "/",
 		Expires:  time.Now().Add(agentCookieDuration),
 		HttpOnly: true,
-		Secure:   true,
+	}
+	if !Config.SetInsecureCookies {
+		cookie.Secure = true
 	}
 	return cookie, nil
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -63,6 +63,7 @@ func init() {
 		"path to file containing a 256-bit key for using local key-management instead of AWS")
 
 	flag.BoolVar(&Config.AllowRoomCreation, "allow-room-creation", true, "allow rooms to be created")
+	flag.BoolVar(&Config.SetInsecureCookies, "set-insecure-cookies", false, "allow non-https cookies")
 
 	flag.StringVar(&Config.Email.Server, "smtp-server", "", "address of SMTP server to send mail through")
 	flag.StringVar(&Config.Email.AuthMethod, "smtp-auth-method", "",
@@ -94,6 +95,7 @@ type ServerConfig struct {
 	AllowRoomCreation     bool          `yaml:"allow_room_creation"`
 	NewAccountMinAgentAge time.Duration `yaml:"new_account_min_agent_age"`
 	RoomEntryMinAgentAge  time.Duration `yaml:"room_entry_min_agent_age"`
+	SetInsecureCookies    bool          `yaml:"set_insecure_cookies"`
 
 	StaticPath    string `yaml:"static_path"`
 	SiteName      string `yaml:"site_name"`

--- a/backend/server.go
+++ b/backend/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	allowRoomCreation     bool
 	newAccountMinAgentAge time.Duration
 	roomEntryMinAgentAge  time.Duration
+	setInsecureCookies    bool
 
 	m sync.Mutex
 
@@ -74,6 +75,7 @@ func NewServer(heim *proto.Heim, id, era string) (*Server, error) {
 func (s *Server) AllowRoomCreation(allow bool)            { s.allowRoomCreation = allow }
 func (s *Server) NewAccountMinAgentAge(age time.Duration) { s.newAccountMinAgentAge = age }
 func (s *Server) RoomEntryMinAgentAge(age time.Duration)  { s.roomEntryMinAgentAge = age }
+func (s *Server) SetInsecureCookies(allow bool)           { s.setInsecureCookies = allow }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.r.ServeHTTP(w, r)

--- a/heim.yml
+++ b/heim.yml
@@ -5,3 +5,4 @@ database:
 kms:
   aes256:
     key-file: /keys/masterkey
+set_insecure_cookies: true

--- a/heimctl/cmd/serve.go
+++ b/heimctl/cmd/serve.go
@@ -91,6 +91,7 @@ func (cmd *serveCmd) run(ctx scope.Context, args []string) error {
 		return fmt.Errorf("server error: %s", err)
 	}
 
+	server.SetInsecureCookies(backend.Config.SetInsecureCookies)
 	server.AllowRoomCreation(backend.Config.AllowRoomCreation)
 	server.NewAccountMinAgentAge(backend.Config.NewAccountMinAgentAge)
 


### PR DESCRIPTION
Per Logan's request, this adds a config file boolean value to control whether the cookies served over the websocket are secure or not. The default is secure. 