### PR TITLE
Sub-rank matches by starting position; final tie-break on name.

### DIFF
--- a/client/lib/mention.js
+++ b/client/lib/mention.js
@@ -20,9 +20,10 @@ module.exports.containsSubseq = function(name, part) {
 }
 
 /**
- * From a name and a partial produce a score. A score of
- * zero indicates "no match whatsoever", all other scores
- * are positive.
+ * From a name and a partial produce a score. Scores are arrays of
+ * constant length and are intended to be compared lexicographically.
+ * Lower values are better matches. If the result is null, there is
+ * no match whatsoever.
  */
 module.exports.scoreMatch = function(name, part) {
   // FIXME Use proper Unicode-aware case-folding, if not already
@@ -35,25 +36,62 @@ module.exports.scoreMatch = function(name, part) {
   var indexOfCs = name.indexOf(part);
   var indexOfCi = nameLowercase.indexOf(partLowercase);
   if (indexOfCs === 0) {
-    return 31
+    return [-31, 0]
   } else if (indexOfCi === 0) {
-    return 30
+    return [-30, 0]
   } else if (indexOfCs >= 0) {
-    return 21
+    return [-21, indexOfCs]
   } else if (indexOfCi >= 0) {
-    return 20
+    return [-20, indexOfCi]
   } else if (module.exports.containsSubseq(name, part)) {
-    return 11
+    return [-11, 0]
   } else if (module.exports.containsSubseq(nameLowercase, partLowercase)) {
-    return 10
+    return [-10, 0]
   } else {
-    return 0
+    return null
   }
+}
+
+/**
+ * Yield {completion, score} for a pair of name, stripped
+ * partial name.
+ */
+function annotateScore(name, partStrip) {
+  var stripped = hueHash.stripSpaces(name)
+  var score = module.exports.scoreMatch(stripped, partStrip)
+  if (score) {
+    // Add tie-breakers. We first sort by lowercased names and
+    // then by the original names so that we don't get orderings
+    // like ["A", "Z", "a"]. This still sorts uppercase before
+    // lowercase, which is fine.
+    score.push(name.toLowerCase(), name)
+  }
+  return {completion: stripped, score: score}
+}
+
+/**
+ * Custom lexicographic comparator on pairs of equal-length
+ * arrays. Does not do a deep comparison on sub-arrays.
+ */
+function compareArrays(a, b) {
+  var len = a.length;
+  for (var i = 0; i < len; i++) {
+    var elA = a[i]
+    var elB = b[i]
+    if (elA < elB) {
+      return -1
+    } else if (elA > elB) {
+      return 1
+    }
+    // continue if equal...
+  }
+  return 0;
 }
 
 /**
  * Given an Immutable Seq of names and a partial name, yield sorted
  * Seq of mentionable names by match relevancy (best first).
+ * Names that do not match at all are omitted from the result.
  * Mentionable names are suitable for use as mentions (do not contain
  * spaces, but do contain emoji, non-ASCII, etc.)
  */
@@ -61,11 +99,14 @@ module.exports.rankCompletions = function(names, part) {
   var partStrip = hueHash.stripSpaces(part)
   return names
     .filter(Boolean)
-    .map(function(name) {
-      var stripped = hueHash.stripSpaces(name)
-      return [stripped, module.exports.scoreMatch(stripped, partStrip)]
-    })
-    .filter(entry => entry[1] > 0)
-    .sortBy(entry => -entry[1])
-    .map(entry => entry[0])
+    .map(name => annotateScore(name, partStrip))
+    .filter(entry => entry.score)
+    // Use a custom lexicographic array sorter because JS's native
+    // array comparison stringifies numeric elements for comparison,
+    // meaning negative numbers compare incorrectly. We need negative
+    // numbers in the score so that better matches come up at the
+    // front -- because that needs to match the tie-breaker of
+    // asciibetical ordering!
+    .sortBy(entry => entry.score, compareArrays)
+    .map(entry => entry.completion)
 }

--- a/client/test/mention-test.js
+++ b/client/test/mention-test.js
@@ -5,57 +5,90 @@ var Immutable = require('immutable')
 describe('mention', function() {
   var mention = require('../lib/mention')
 
-  describe('containsSubseq', function() {
-    function assertContains(n, p, yes) {
-      assert.equal(mention.containsSubseq(n, p), yes)
+  describe('findSubseq', function() {
+    function assertFinding(n, p, start) {
+      assert.deepEqual(mention.findSubseq(n, p), start)
     }
 
     it('handles empty and exact matches', function() {
-      assertContains('', '', true)
-      assertContains('name', '', true)
-      assertContains('', 'cruft', false)
-      assertContains('name', 'name', true)
+      assertFinding('', '', -1)
+      assertFinding('name', '', -1)
+      assertFinding('', 'cruft', -1)
+      assertFinding('name', 'name', 0)
     })
     it('rejects extra on end of partial', function() {
-      assertContains('name', 'namex', false)
+      assertFinding('name', 'namex', -1)
     })
-    it('finds standard cases', function() {
-      assertContains('name', 'nm', true)
-      assertContains('name', 'e', true)
+    it('does not case-fold', function() {
+      assertFinding('name', 'NAME', -1)
+      assertFinding('NAME', 'name', -1)
+      assertFinding('NAME', 'NAME', 0)
+    })
+    it('yields correct start in corner cases', function() {
+      assertFinding('a', 'a', 0)
+      assertFinding('name', 'n', 0)
+      assertFinding('name', 'nm', 0)
+      assertFinding('name', 'e', 3)
+    })
+    it('finds earliest subseq', function() {
+      assertFinding('aaaa', 'a', 0)
+      assertFinding('namename', 'am', 1)
+      assertFinding('ABxxBxCxxD', 'BCD', 1)
     })
     // This is a possible index bug.
     it('rejects extra chars going off the end', function() {
-      assertContains('name', 'es', false)
+      assertFinding('name', 'es', -1)
     })
     it('respects order', function() {
-      assertContains('name', 'eman', false)
+      assertFinding('name', 'eman', -1)
     })
     it('respects count (always advance)', function() {
-      assertContains('name', 'nnm', false)
+      assertFinding('name', 'nnm', -1)
+    })
+  })
+
+  // These tests are more perfunctory since scoreMatch is the real
+  // deal; this is just a supporting fn.
+  describe('matchPinningCase', function() {
+    function check(name, prefix, match) {
+      assert.deepEqual(mention.matchPinningCase(name, prefix), match)
+    }
+    it('matches without case-folding', function() {
+      check('TimMc', 'timmc', null)
+      check('timmc', 'TimMc', null)
+      check('TimMc', 'TimMc', [-1, -1, 0])
+    })
+    it('prefers contiguous match over earlier subsequence', function() {
+      check('timmc', 'mc', [-1, 0, 3])
+      check('timxc', 'mc', [0, 0, 2])
     })
   })
 
   describe('scoreMatch', function() {
-    
+    function scoreEqual(name, prefix, score) {
+      assert.deepEqual(mention.scoreMatch(name, prefix), score)
+    }
+
     it('scores entirely bad matches as null', function() {
-      assert.deepEqual(mention.scoreMatch('', 'something'), null)
-      assert.deepEqual(mention.scoreMatch('1', '2'), null)
+      scoreEqual('', 'something', null)
+      scoreEqual('1', '2', null)
     })
-    it('empty prefix always matches', function() {
-      assert.deepEqual(mention.scoreMatch('', ''), [-31, 0])
-      assert.deepEqual(mention.scoreMatch('something', ''), [-31, 0])
+    it('empty prefix doesn\'t match', function() {
+      scoreEqual('', '', null)
+      scoreEqual('something', '', null)
     })
-    it('has expected score levels for a single name', function() {
+    it('produces lower scores for better matches', function() {
       // Exact match scores same as prefix for now.
-      assert.deepEqual(mention.scoreMatch('TimMc', 'TimMc'), [-31, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'timmc'), [-30, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'Tim'), [-31, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'tim'), [-30, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'imM'), [-21, 1])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'imm'), [-20, 1])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'TM'), [-11, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'tm'), [-10, 0])
-      assert.deepEqual(mention.scoreMatch('TimMc', 'no'), null)
+      scoreEqual('TimMc', 'TimMc', [-1, -1, -1, 0])
+      scoreEqual('TimMc', 'timmc', [-1, -1, 0, 0])
+      scoreEqual('TimMc', 'Tim', [-1, -1, -1, 0])
+      scoreEqual('TimMc', 'tim', [-1, -1, 0, 0])
+      scoreEqual('TimMc', 'imM', [-1, 0, -1, 1])
+      scoreEqual('TimMc', 'imm', [-1, 0, 0, 1])
+      scoreEqual('TimMc', 'mc', [-1, 0, 0, 3])
+      scoreEqual('TimMc', 'TM', [0, 0, -1, 0])
+      scoreEqual('TimMc', 'tm', [0, 0, 0, 0])
+      scoreEqual('TimMc', 'no', null)
     })
   })
 
@@ -77,7 +110,7 @@ describe('mention', function() {
       // we could treat prefix as a high-scoring infix.
       assertRanking(users, 'M', ['Max2', 'mac', 'TimMc', 'chromakode'])
     })
-    it('ranks subseqs less than infix ci', function() {
+    it('infix over subseq, even when earlier and case-match', function() {
       assertRanking(users, 'mc', ['TimMc', 'mac'])
     })
     it('sorts asciibetically as tie-breaker, caps first', function() {
@@ -88,8 +121,12 @@ describe('mention', function() {
       assertRanking(['aXX', 'bbXX'], 'XX', ['aXX', 'bbXX'])
       assertRanking(['aaXX', 'bXX'], 'XX', ['bXX', 'aaXX'])
     })
+    it('ranks earlier subseq over later', function() {
+      assertRanking(['xAxB', 'xxAxB'], 'ab', ['xAxB', 'xxAxB'])
+      assertRanking(['xBxA', 'xxBxA'], 'ba', ['xBxA', 'xxBxA'])
+    })
     it('strips spaces from names', function() {
-      assertRanking(users, 'x2', ['Max2'])
+      assertRanking([' Max 2 '], 'x2', ['Max2'])
     })
   })
 })


### PR DESCRIPTION
- This allows `cr` to match `scrapple` before `desecrate`, because it appears sooner in the word. Sub-sequence scoring is similarly affected by this change.
- There is now a tie-breaker comparison of names if all else is equal. (This is particularly helpful because the user store is not sorted.) I didn't look too closely at what happens when there are spaces in different positions in the names.

Numeric scores are negated to match the lower-score-is-better behavior
needed for comparing name strings directly (as fallback); to match this
the sort is now done forwards instead of negating in the sortBy.

We also switch to complex scores, lexicographically sorted, in order to
support more nuanced infix comparisons.