### PR TITLE
Don't display emoji title texts in the user list

### DIFF
--- a/client/lib/main.less
+++ b/client/lib/main.less
@@ -519,6 +519,10 @@ iframe.js {
       box-sizing: border-box;
       margin: 2px 0;
       white-space: nowrap;
+
+      .emoji {
+        pointer-events: none;
+      }
     }
   }
 }


### PR DESCRIPTION
There's two behaviors conflicting for "consistency" here, and the nick's title text includes all the emoji expanded anyway.

**Not covered**: Unicode emoji which would be translated into their colons-and-text expansions.