### PR TITLE
Dedupe "distribute" in licensed rights to User Content.

### DIFF
--- a/client/site/about/terms.md
+++ b/client/site/about/terms.md
@@ -142,7 +142,7 @@ rights notices incorporated in or accompanying the Services or Content.
 By making any User Content available through Services you hereby grant to
 Euphoria a non-exclusive, transferable, sublicenseable, worldwide, royalty-free
 license to use, host, copy, modify, store, cache, reproduce, create derivative
-works based upon, distribute, publicly display, publicly perform, and
+works based upon, publicly display, publicly perform, and
 distribute your User Content in connection with operating and providing the
 Services and Content to you and to other users. Please note, this license grant
 continues even if you stop using the Services mainly because of the nature of


### PR DESCRIPTION
I assume you wanted the second instance. It certainly flows better that way...