### PR TITLE
Include room title in HTML response.

### DIFF
--- a/client/lib/room.html
+++ b/client/lib/room.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>euphoria</title>
+  <title>{{.RoomName}}</title>
   <link rel="icon" id="favicon" href="<%- HEIM_PREFIX %>/static/favicon.png" sizes="32x32">
   <link rel="icon" href="<%- HEIM_PREFIX %>/static/favicon-192.png" sizes="192x192">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">


### PR DESCRIPTION
This will improve the display of room pages in contexts where the page is staticly scraped for metadata, such as some browser UI contexts like Chrome's new tab page. As a drawback, we lose http.ServeContent's handling of `Last-Modified`, though these pages weigh in at just a kb, so I didn't sweat it.

Does this look reasonable @logan?