### PR TITLE
Fix #42.

### DIFF
--- a/client/lib/ui/message-copy-formatter.js
+++ b/client/lib/ui/message-copy-formatter.js
@@ -8,6 +8,9 @@ var emoji = require('../emoji')
 
 module.exports = function handleCopy(ev) {
   var selection = uiwindow.getSelection()
+  if (selection.rangeCount === 0) {
+    return
+  }
   var range = selection.getRangeAt(0)
 
   // first, if the selection start and end are within the same message


### PR DESCRIPTION
As I've described in [my comment in #42](https://github.com/euphoria-io/heim/issues/42#issuecomment-154867834), I believe that IE's implementation of `window.getSelection()` does not count a selection in a text input field as a range.

Therefore, I believe that this PR should fix #42 by checking if `selection.rangeCount` is 0 before calling `selection.getRangeAt(0)`.