### PR TITLE
Fix imgur duplication bug :D

### DIFF
--- a/client/lib/ui/Message.js
+++ b/client/lib/ui/Message.js
@@ -391,7 +391,7 @@ const Message = React.createClass({
     const embeds = []
     content = content.replace(/(?:https?:\/\/)?(?:www\.|i\.|m\.)?imgur\.com\/(\w+)(\.\w+)?(\S*)/g, (match, id, ext, rest, offset, string) => {
       if (rest) {
-        return string
+        return match
       }
       embeds.push({
         link: '//imgur.com/' + id,

--- a/client/lib/ui/Message.js
+++ b/client/lib/ui/Message.js
@@ -389,7 +389,7 @@ const Message = React.createClass({
 
     let content = message.get('content')
     const embeds = []
-    content = content.replace(/(?:https?:\/\/)?(?:www\.|i\.|m\.)?imgur\.com\/(\w+)(\.\w+)?(\S*)/g, (match, id, ext, rest, offset, string) => {
+    content = content.replace(/(?:https?:\/\/)?(?:www\.|i\.|m\.)?imgur\.com\/(\w+)(\.\w+)?(\S*)/g, (match, id, ext, rest) => {
       if (rest) {
         return match
       }


### PR DESCRIPTION
@chromakode, I finally found it.
FYI, the `string` variable contains not only the matched string, but also everything around it, replacing every "invalid" imgur link with a copy of the whole "original" message.