### PR TITLE
Make emote messages contents “dock” to nickname correctly

### DIFF
--- a/client/lib/main.less
+++ b/client/lib/main.less
@@ -1460,6 +1460,9 @@ iframe.js {
         padding-left: 3px;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
+        // make height and baseline match nick
+        padding-top: 1px;
+        padding-bottom: 1px;
       }
 
       .ago {


### PR DESCRIPTION
In the current styling, emotes are not only a bit too short, but their baselines are also below that one of the nick.

*Current styling:*
![emote1](https://cloud.githubusercontent.com/assets/12989435/14943354/ebbc0156-0fd6-11e6-8e65-ced9b651f17e.png)

*(Darkened for better visibility:)*
![emote2](https://cloud.githubusercontent.com/assets/12989435/14943355/ebbe802a-0fd6-11e6-8f85-5bbde7087ea4.png)
