### PR TITLE
Allow youtube videos to be played twice in a row

### DIFF
--- a/client/lib/fauxPlugins.js
+++ b/client/lib/fauxPlugins.js
@@ -152,7 +152,7 @@ export default function initPlugins(roomName) {
       },
 
       shouldComponentUpdate(nextProps) {
-        return nextProps.youtubeId !== this.props.youtubeId || nextProps.youtubeTime !== this.props.youtubeTime
+        return true
       },
 
       render() {

--- a/client/lib/fauxPlugins.js
+++ b/client/lib/fauxPlugins.js
@@ -151,10 +151,6 @@ export default function initPlugins(roomName) {
         className: React.PropTypes.string,
       },
 
-      shouldComponentUpdate(nextProps) {
-        return true
-      },
-
       render() {
         return (
           <Embed


### PR DESCRIPTION
It comes up fairly often that a user wants to play a video twice in a row, whether they missed hearing it or for some other reason. Currently, using `!play [url]` twice results in the video only playing once. This PR changes the youtube plugin to always update upon a `!play` command, instead of only when the times or ids are different.