### PR TITLE
Don't allow replies to deleted messages.

### DIFF
--- a/backend/psql/room.go
+++ b/backend/psql/room.go
@@ -146,7 +146,7 @@ func (rb *RoomBinding) getParentPostTime(id snowflake.Snowflake) (time.Time, err
 		Posted time.Time
 	}
 	err := rb.DbMap.SelectOne(&row,
-		"SELECT posted FROM message WHERE room = $1 AND id = $2",
+		"SELECT posted FROM message WHERE room = $1 AND id = $2 AND deleted IS NULL",
 		rb.RoomName, id.String())
 	if err != nil {
 		return time.Time{}, err


### PR DESCRIPTION
Currently, when a message is deleted, users may be typing a reply to that message. If the timing is right then the user sends the message just after the parent message is deleted. This results in a reply to the deleted message appearing at the top level.

This PR changes getParentPostTime to return an error, resulting in a reply to the deleted message being dropped.