### PR TITLE
Trim thread pane and notification list entries

### DIFF
--- a/client/lib/ui/NotificationListItem.js
+++ b/client/lib/ui/NotificationListItem.js
@@ -52,7 +52,7 @@ export default React.createClass({
 
     return (
       <FastButton component="div" className={classNames('notification', this.props.kind, {'seen': message.get('_seen')})} onClick={ev => this.props.onClick(ev, this.props.nodeId)}>
-        <MessageText className="title" content={message.get('content')} maxLength={140} />
+        <MessageText className="title" content={message.get('content').trim()} maxLength={140} />
         <LiveTimeAgo className="ago" time={message.get('time')} nowText="active" />
       </FastButton>
     )

--- a/client/lib/ui/NotificationListItem.js
+++ b/client/lib/ui/NotificationListItem.js
@@ -52,7 +52,7 @@ export default React.createClass({
 
     return (
       <FastButton component="div" className={classNames('notification', this.props.kind, {'seen': message.get('_seen')})} onClick={ev => this.props.onClick(ev, this.props.nodeId)}>
-        <MessageText className="title" content={message.get('content').trim()} maxLength={140} />
+        <MessageText className="title" content={(message.get('content') || '').trim()} maxLength={140} />
         <LiveTimeAgo className="ago" time={message.get('time')} nowText="active" />
       </FastButton>
     )

--- a/client/lib/ui/ThreadListItem.js
+++ b/client/lib/ui/ThreadListItem.js
@@ -69,7 +69,7 @@ const ThreadListItem = React.createClass({
     return (
       <div className="thread">
         <FastButton component="div" data-thread-id={this.props.threadNodeId} className={classNames('info', {'selected': this.state.threadData.get('selected'), 'active': isActive})} onClick={ev => this.props.onClick(ev, this.props.threadNodeId)}>
-          <MessageText className="title" content={message.get('content').trim()} maxLength={140} />
+          <MessageText className="title" content={(message.get('content') || '').trim()} maxLength={140} />
           {newCount > 0 && <span className={classNames('new-count', {'new-mention': count.get('newMentionDescendants') > 0})}>{newCount}</span>}
           <LiveTimeAgo className="ago" time={timestamp} nowText="active" />
         </FastButton>

--- a/client/lib/ui/ThreadListItem.js
+++ b/client/lib/ui/ThreadListItem.js
@@ -69,7 +69,7 @@ const ThreadListItem = React.createClass({
     return (
       <div className="thread">
         <FastButton component="div" data-thread-id={this.props.threadNodeId} className={classNames('info', {'selected': this.state.threadData.get('selected'), 'active': isActive})} onClick={ev => this.props.onClick(ev, this.props.threadNodeId)}>
-          <MessageText className="title" content={message.get('content')} maxLength={140} />
+          <MessageText className="title" content={message.get('content').trim()} maxLength={140} />
           {newCount > 0 && <span className={classNames('new-count', {'new-mention': count.get('newMentionDescendants') > 0})}>{newCount}</span>}
           <LiveTimeAgo className="ago" time={timestamp} nowText="active" />
         </FastButton>


### PR DESCRIPTION
Messages containing lots of whitespace would cause large blank spaces not
carrying any particular meaning.