### PR TITLE
Fix user list bug

### DIFF
--- a/client/lib/ui/UserList.js
+++ b/client/lib/ui/UserList.js
@@ -71,7 +71,7 @@ export default React.createClass({
       }
       prevUser = user
       return true
-    })
+    }).toList()
     return (
       <div className="user-list" {...this.props}>
         {people && <div className="list">


### PR DESCRIPTION
If there is only one user, they would not be displayed when using the development frontend.
It has very probably to do with the deduplication, and might be related to repeated evaluation of the (stateful!) filter, so that the single entry becomes (erroneously) deduplicated upon repeated iterations; an eager (and therefore single) evaluation of the filter is forced using the `toList()`.
The behavior is for unknown reasons not observed in the production frontend.