### PR TITLE
Fix Go linker warning

### DIFF
--- a/backend/run.sh
+++ b/backend/run.sh
@@ -3,7 +3,7 @@
 set -ex
 
 go install \
-    -ldflags "-X main.version `git --git-dir=src/euphoria.io/heim/.git rev-parse HEAD`" \
+    -ldflags "-X main.version=`git --git-dir=src/euphoria.io/heim/.git rev-parse HEAD`" \
     euphoria.io/heim/heimctl
 
 export PATH=/go/bin:"$PATH"


### PR DESCRIPTION
To quote the commit message,

> It's been there since... virtually forever, is mildly annoying, and
> might break things at some point.

Also, it's trivial, and does exactly what the same warning recommends.