### PR TITLE
Disallow replies to nonexistent messages

### DIFF
--- a/backend/psql/room.go
+++ b/backend/psql/room.go
@@ -822,7 +822,7 @@ func (rb *ManagedRoomBinding) MinAgentAge() time.Duration {
 }
 
 func (rb *ManagedRoomBinding) IsValidParent(id snowflake.Snowflake) (bool, error) {
-	if id.String() == "" || rb.RetentionDays == 0 {
+	if id.String() == "" {
 		return true, nil
 	}
 	posted, err := rb.getParentPostTime(id)
@@ -832,6 +832,9 @@ func (rb *ManagedRoomBinding) IsValidParent(id snowflake.Snowflake) (bool, error
 			return false, nil
 		}
 		return false, err
+	}
+	if rb.RetentionDays == 0 {
+		return true, nil
 	}
 	threshold := time.Now().Add(time.Duration(-rb.RetentionDays) * 24 * time.Hour)
 	if posted.Before(threshold) {


### PR DESCRIPTION
The former behavior was to allow replies to any message in managed rooms with unlimited message retention, in contrast to unmanaged rooms, which did check.

The bug was introduced in 1debaa5919b29e9279ffc2d419bd03a8edea6cd3 (the initial implementation), and undone for unmanaged rooms in 4959f3f39b28430ae6d66fe37c0d7cdfb2a118e5 (the initial implementation of those, if I interpret the diff correctly).