### PR TITLE
Fix notice display

### DIFF
--- a/client/lib/main.less
+++ b/client/lib/main.less
@@ -639,9 +639,7 @@ iframe.js {
   }
 
   .notice-stack {
-    position: absolute;
-    left: 0;
-    right: 0;
+    height: 0;
     z-index: 11;
   }
 


### PR DESCRIPTION
Chrome and (starting with version 52) Firefox both push the absolutely positioned `.notice-stack` upwards to the top of the page. A zero height on the element instead of that leads to the same appearance of the notices (which now overflow their container) hovering over the scrollbar as observed previously without the repositioning.