### PR TITLE
Improve @-mention UX

### DIFF
--- a/client/lib/stores/chat.js
+++ b/client/lib/stores/chat.js
@@ -12,7 +12,7 @@ import hueHash from '../hueHash'
 
 
 const mentionDelim = String.raw`^|$|[,.!?;&<'"\s]|&#39;|&quot;|&amp;`
-const mentionFindRe = module.exports.mentionFindRe = new RegExp('(' + mentionDelim + String.raw`)@(\S+?)(?=` + mentionDelim + ')', 'g')
+const mentionFindRe = module.exports.mentionFindRe = new RegExp('(' + mentionDelim + String.raw`|[([{])@(\S+?)(?=` + mentionDelim + String.raw`|[)\]}])`, 'g')
 
 const storeActions = module.exports.actions = Reflux.createActions([
   'messageReceived',

--- a/client/lib/stores/chat.js
+++ b/client/lib/stores/chat.js
@@ -12,7 +12,7 @@ import hueHash from '../hueHash'
 
 
 const mentionDelim = String.raw`^|$|[,.!?;&<'"\s]|&#39;|&quot;|&amp;`
-const mentionFindRe = module.exports.mentionFindRe = new RegExp('(' + mentionDelim + String.raw`|[([{])@(\S+?)(?=` + mentionDelim + String.raw`|[)\]}])`, 'g')
+const mentionFindRe = module.exports.mentionFindRe = new RegExp('(' + mentionDelim + String.raw`|[([{])@(\S+)(?=` + mentionDelim + String.raw`|[)\]}])`, 'g')
 
 const storeActions = module.exports.actions = Reflux.createActions([
   'messageReceived',

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -142,6 +142,7 @@ export default React.createClass({
       return
     }
 
+    // Scan backwards for beginning of word
     let wordStart
     for (wordStart = wordEnd - 1; wordStart >= 0; wordStart--) {
       if (!charRe.test(text[wordStart])) {
@@ -149,10 +150,17 @@ export default React.createClass({
       }
     }
     wordStart++
-    if (text[wordStart] === '@') {
-      wordStart++
+
+    // Scan forward for the first @ sign
+    let mentionStart
+    for (mentionStart = wordStart; mentionStart < text.length && charRe.test(text[mentionStart]); mentionStart++) {
+      if (text[mentionStart] == '@') {
+        wordStart = mentionStart + 1
+        break
+      }
     }
 
+    // Scan forward for end of word
     for (; wordEnd < text.length; wordEnd++) {
       if (!charRe.test(text[wordEnd])) {
         break


### PR DESCRIPTION
This patch allows for the use case of @-mentions inside parentheses (as it used to be, IIRC), and tab-completing @-mentions inside those.