### PR TITLE
Avoid crashes with deep threads

### DIFF
--- a/client/lib/ui/Message.js
+++ b/client/lib/ui/Message.js
@@ -306,11 +306,12 @@ const Message = React.createClass({
       }
     } else if (children.size > 0 || focused) {
       const composingReply = focused && children.size === 0
-      const canCollapse = (children.size > this.props.visibleCount && !showAllReplies) || this.props.maxDepth == 0
-      const inlineReplies = composingReply || !canCollapse
+      const fullCollapse = this.props.visibleCount == 0 && !showAllReplies || this.props.maxDepth == 0
+      const partialCollapse = children.size > this.props.visibleCount && !showAllReplies && !fullCollapse
+      const inlineReplies = composingReply || !fullCollapse
       let childCount
       let childNewCount
-      if (!inlineReplies && !repliesExpanded) {
+      if (fullCollapse && !repliesExpanded) {
         childCount = count.get('descendants')
         childNewCount = count.get('newDescendants')
         let replyLabel
@@ -350,7 +351,7 @@ const Message = React.createClass({
       } else {
         let focusAction
         let expandRestOfReplies
-        if (canCollapse && !repliesExpanded) {
+        if (partialCollapse && !repliesExpanded) {
           const descCount = this.props.tree.calculateDescendantCount(this.props.nodeId, this.props.visibleCount)
           childCount = descCount.get('descendants')
           childNewCount = descCount.get('newDescendants')
@@ -386,11 +387,11 @@ const Message = React.createClass({
           focusAction = <ChatEntry pane={pane} onChange={this.expandReplies} />
         }
         let collapseAction
-        if (canCollapse) {
+        if (fullCollapse || partialCollapse) {
           collapseAction = repliesExpanded ? this.collapseReplies : this.expandReplies
         }
         messageReplies = (
-          <div ref="replies" className={classNames('replies', {'collapsible': canCollapse, 'expanded': canCollapse && repliesExpanded, 'inline': inlineReplies, 'empty': children.size === 0, 'focused': focused})}>
+          <div ref="replies" className={classNames('replies', {'collapsible': fullCollapse || partialCollapse, 'expanded': repliesExpanded, 'inline': inlineReplies, 'empty': children.size === 0, 'focused': focused})}>
             <FastButton className="indent-line" onClick={collapseAction} empty />
             <div className="content">
               {children.toIndexedSeq().map((nodeId, idx) =>

--- a/client/lib/ui/Message.js
+++ b/client/lib/ui/Message.js
@@ -35,6 +35,7 @@ const Message = React.createClass({
     showAllReplies: React.PropTypes.bool,
     depth: React.PropTypes.number,
     visibleCount: React.PropTypes.number,
+    maxDepth: React.PropTypes.number,
     roomSettings: React.PropTypes.instanceOf(Immutable.Map),
   },
 
@@ -46,6 +47,7 @@ const Message = React.createClass({
 
   statics: {
     visibleCount: 5,
+    maxDepth: 50,
     newFadeDuration: 60 * 1000,
   },
 
@@ -53,6 +55,7 @@ const Message = React.createClass({
     return {
       depth: 0,
       visibleCount: this.visibleCount - 1,
+      maxDepth: this.maxDepth - 1,
       showTimeStamps: false,
       showTimeAgo: false,
       showAllReplies: false,
@@ -230,7 +233,12 @@ const Message = React.createClass({
     const contentExpanded = paneData.get('contentExpanded')
 
     let repliesExpanded
-    if (showAllReplies) {
+    if (this.props.maxDepth == 0) {
+      repliesExpanded = paneData.get('repliesExpanded')
+      if (repliesExpanded === null) {
+        repliesExpanded = false
+      }
+    } else if (showAllReplies) {
       repliesExpanded = true
     } else {
       repliesExpanded = paneData.get('repliesExpanded')
@@ -298,7 +306,8 @@ const Message = React.createClass({
       }
     } else if (children.size > 0 || focused) {
       const composingReply = focused && children.size === 0
-      const inlineReplies = composingReply || this.props.visibleCount > 0 || showAllReplies
+      const canCollapse = (children.size > this.props.visibleCount && !showAllReplies) || this.props.maxDepth == 0
+      const inlineReplies = composingReply || !canCollapse
       let childCount
       let childNewCount
       if (!inlineReplies && !repliesExpanded) {
@@ -341,7 +350,6 @@ const Message = React.createClass({
       } else {
         let focusAction
         let expandRestOfReplies
-        const canCollapse = !showAllReplies && children.size > this.props.visibleCount
         if (canCollapse && !repliesExpanded) {
           const descCount = this.props.tree.calculateDescendantCount(this.props.nodeId, this.props.visibleCount)
           childCount = descCount.get('descendants')
@@ -386,7 +394,7 @@ const Message = React.createClass({
             <FastButton className="indent-line" onClick={collapseAction} empty />
             <div className="content">
               {children.toIndexedSeq().map((nodeId, idx) =>
-                <Message key={nodeId} pane={this.props.pane} tree={this.props.tree} nodeId={nodeId} depth={this.props.depth + 1} visibleCount={repliesExpanded ? Message.visibleCount : Math.floor((this.props.visibleCount - 1) / 2)} showTimeAgo={!expandRestOfReplies && idx === children.size - 1} showTimeStamps={this.props.showTimeStamps} roomSettings={this.props.roomSettings} />
+                <Message key={nodeId} pane={this.props.pane} tree={this.props.tree} nodeId={nodeId} depth={this.props.depth + 1} visibleCount={repliesExpanded ? Message.visibleCount : Math.floor((this.props.visibleCount - 1) / 2)} maxDepth={this.props.maxDepth == 0 ? Message.maxDepth - 1 : this.props.maxDepth - 1} showTimeAgo={!expandRestOfReplies && idx === children.size - 1} showTimeStamps={this.props.showTimeStamps} roomSettings={this.props.roomSettings} />
               )}
               {focusAction}
             </div>


### PR DESCRIPTION
Although the Euphoria-side thread depth limit has fallen, React still starts behaving badly when too deeply nested messages appear, leading to looping crashes in certain situations (e.g. `showAllReplies` enabled or a very deep thread the user posted in), potentially rendering Euphoria entirely unusable.
This avoids the problem by forcing a collapse (disregarding `showAllReplies`) at a (large) depth as a “safety net” against the crashes.
The user can still risk seeing the remainder of the thread by expanding the collapsed reply section.