### PR TITLE
Fix page location reading in Chrome

### DIFF
--- a/client/lib/clientRoom.js
+++ b/client/lib/clientRoom.js
@@ -35,7 +35,7 @@ export default function clientRoom() {
 
     // read url hash flags pertaining to socket connection
     const roomName = uiwindow.location.pathname.match(/((pm:)?\w+)\/$/)[1]
-    const hashFlags = queryString.parse(location.hash.substr(1))
+    const hashFlags = queryString.parse(uiwindow.location.hash.substr(1))
     let connectEndpoint = process.env.HEIM_ORIGIN + process.env.HEIM_PREFIX
     if (process.env.NODE_ENV !== 'production' && hashFlags.connect) {
       connectEndpoint = hashFlags.connect

--- a/client/lib/fauxPlugins.js
+++ b/client/lib/fauxPlugins.js
@@ -366,7 +366,7 @@ export default function initPlugins(roomName) {
     Heim.chat.setRoomSettings({collapse: false})
   }
 
-  if (location.hash.substr(1) === 'spooky') {
+  if (uiwindow.location.hash.substr(1) === 'spooky') {
     Heim.hook('page-bottom', () => {
       return (
         <style key="spooky-style" dangerouslySetInnerHTML={{__html: `
@@ -611,7 +611,7 @@ export default function initPlugins(roomName) {
     })
   }
 
-  if (location.hash.substr(1) === 'darcula') {
+  if (uiwindow.location.hash.substr(1) === 'darcula') {
     Heim.hook('page-bottom', () => {
       return (
           <style key="darcula-style" dangerouslySetInnerHTML={{__html: `
@@ -824,7 +824,7 @@ export default function initPlugins(roomName) {
       )
     })
 
-    if (location.hash.substr(1) === 'spooky') {
+    if (uiwindow.location.hash.substr(1) === 'spooky') {
       Heim.hook('page-bottom', () => {
         return (
           <style key="xkcd-top-spooky-style" dangerouslySetInnerHTML={{__html: `
@@ -835,7 +835,7 @@ export default function initPlugins(roomName) {
           `}} />
         )
       })
-    } else if (location.hash.substr(1) === 'darcula') {
+    } else if (uiwindow.location.hash.substr(1) === 'darcula') {
       Heim.hook('page-bottom', () => {
         return (
           <style key="xkcd-top-darcula-style" dangerouslySetInnerHTML={{__html: `


### PR DESCRIPTION
Chrome started setting the location of the iframe containing the bulk
of the client code slightly differently to that one of the top-level
window in some unknown version; the iframe does now not contain the
fragment identifier of the top-level window, which some things
(including custom themes and development the frontend against upstream
backends) depended on.

Ironically, a follow-up to 3ba8a2ec50efedbce41723392b7f9abe7ac5976f.