### PR TITLE
Add Go import comments.

### DIFF
--- a/aws/kms/kms.go
+++ b/aws/kms/kms.go
@@ -1,4 +1,4 @@
-package kms
+package kms // import "euphoria.io/heim/aws/kms"
 
 import (
 	"fmt"

--- a/backend/console/staff.go
+++ b/backend/console/staff.go
@@ -1,4 +1,4 @@
-package console
+package console // import "euphoria.io/heim/backend/console"
 
 import (
 	"euphoria.io/heim/proto/security"

--- a/backend/mock/doc.go
+++ b/backend/mock/doc.go
@@ -1,1 +1,1 @@
-package mock
+package mock // import "euphoria.io/heim/backend/mock"

--- a/backend/pages.go
+++ b/backend/pages.go
@@ -1,4 +1,4 @@
-package backend
+package backend // import "euphoria.io/heim/backend"
 
 import (
 	"bytes"

--- a/backend/psql/ban.go
+++ b/backend/psql/ban.go
@@ -1,4 +1,4 @@
-package psql
+package psql // import "euphoria.io/heim/backend/psql"
 
 import (
 	"database/sql"

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,4 +1,4 @@
-package cluster
+package cluster // import "euphoria.io/heim/cluster"
 
 import (
 	"fmt"

--- a/cluster/etcd/clustertest/testetcd.go
+++ b/cluster/etcd/clustertest/testetcd.go
@@ -1,4 +1,4 @@
-package clustertest
+package clustertest // import "euphoria.io/heim/cluster/etcd/clustertest"
 
 import (
 	"bufio"

--- a/cluster/etcd/etcd.go
+++ b/cluster/etcd/etcd.go
@@ -1,4 +1,4 @@
-package etcd
+package etcd // import "euphoria.io/heim/cluster/etcd"
 
 import (
 	"encoding/hex"

--- a/heimctl/activity/metrics.go
+++ b/heimctl/activity/metrics.go
@@ -1,4 +1,4 @@
-package activity
+package activity // import "euphoria.io/heim/heimctl/activity"
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/heimctl/cmd/activity.go
+++ b/heimctl/cmd/activity.go
@@ -1,4 +1,4 @@
-package cmd
+package cmd // import "euphoria.io/heim/heimctl/cmd"
 
 import (
 	"flag"

--- a/heimctl/presence/server.go
+++ b/heimctl/presence/server.go
@@ -1,4 +1,4 @@
-package presence
+package presence // import "euphoria.io/heim/heimctl/presence"
 
 import (
 	"fmt"

--- a/heimctl/retention/scanner.go
+++ b/heimctl/retention/scanner.go
@@ -1,4 +1,4 @@
-package retention
+package retention // import "euphoria.io/heim/heimctl/retention"
 
 import (
 	"database/sql"

--- a/heimctl/worker/emails.go
+++ b/heimctl/worker/emails.go
@@ -1,4 +1,4 @@
-package worker
+package worker // import "euphoria.io/heim/heimctl/worker"
 
 import (
 	"euphoria.io/heim/proto"

--- a/proto/client.go
+++ b/proto/client.go
@@ -1,4 +1,4 @@
-package proto
+package proto // import "euphoria.io/heim/proto"
 
 import (
 	"fmt"

--- a/proto/emails/deliverer.go
+++ b/proto/emails/deliverer.go
@@ -1,4 +1,4 @@
-package emails
+package emails // import "euphoria.io/heim/proto/emails"
 
 import (
 	"fmt"

--- a/proto/jobs/claim.go
+++ b/proto/jobs/claim.go
@@ -1,4 +1,4 @@
-package jobs
+package jobs // import "euphoria.io/heim/proto/jobs"
 
 import (
 	"bytes"

--- a/proto/logging/logging.go
+++ b/proto/logging/logging.go
@@ -1,4 +1,4 @@
-package logging
+package logging // import "euphoria.io/heim/proto/logging"
 
 import (
 	"io"

--- a/proto/security/grants.go
+++ b/proto/security/grants.go
@@ -1,4 +1,4 @@
-package security
+package security // import "euphoria.io/heim/proto/security"
 
 import (
 	"encoding/base64"

--- a/proto/snowflake/snowflake.go
+++ b/proto/snowflake/snowflake.go
@@ -1,4 +1,4 @@
-package snowflake
+package snowflake // import "euphoria.io/heim/proto/snowflake"
 
 import (
 	"encoding/json"

--- a/templates/email.go
+++ b/templates/email.go
@@ -1,4 +1,4 @@
-package templates
+package templates // import "euphoria.io/heim/templates"
 
 import (
 	"bufio"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
