### PR TITLE
Send the previous edit ID along with message editing requests

### DIFF
--- a/client/lib/stores/chat.js
+++ b/client/lib/stores/chat.js
@@ -686,9 +686,11 @@ module.exports.store = Reflux.createStore({
   },
 
   editMessage(id, data) {
+    const msg = this.state.messages.get(id)
+    const previous_edit_id = msg && msg.get('previous_edit_id')
     this.socket.send({
       type: 'edit-message',
-      data: _.merge(data, {id}),
+      data: _.merge(data, {id, previous_edit_id}),
     })
   },
 


### PR DESCRIPTION
The former behavior of the frontend made it impossible to delete (using the standard UI tools) messages that had been undeleted.